### PR TITLE
Fix file write

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Marcel Müller <neikos@neikos.email>"]
 name = "rustbreak"
-version = "0.2.0"
+version = "0.2.1"
 description = "A single file database"
 documentation = "http://neikos.me/rustbreak/rustbreak/index.html"
 homepage = "https://github.com/TheNeikos/rustbreak"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl<T: Serialize + Deserialize + Eq + Hash> Database<T> {
     pub fn flush(&self) -> BreakResult<()> {
         use bincode::serde::serialize;
         use bincode::SizeLimit;
-        use std::io::Write;
+        use std::io::{Write, Seek, SeekFrom};
 
         let map = match self.data.read() {
             Ok(guard) => guard,
@@ -220,8 +220,10 @@ impl<T: Serialize + Deserialize + Eq + Hash> Database<T> {
         };
 
         let buf = try!(serialize(&*map, SizeLimit::Infinite));
+        try!(file.set_len(0));
+        try!(file.seek(SeekFrom::Start(0)));
         try!(file.write(&buf));
-        try!(file.flush());
+        try!(file.sync_all());
         Ok(())
     }
 


### PR DESCRIPTION
We weren't truncating the file at the start, this means that if the next write is smaller than the previous one the file might have garbage at the end
