### PR TITLE
Try to build on more targets than just standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,9 @@ matrix:
       rust: nightly
 script:
 - |
-  cargo build --features yaml_enc,bin_enc,ron_enc &&
-  cargo test --features yaml_enc,bin_enc,ron_enc &&
-  cargo doc --features yaml_enc,bin_enc,ron_enc
+  cargo build --target "$TARGET" --features yaml_enc,bin_enc,ron_enc &&
+  cargo test  --target "$TARGET" --features yaml_enc,bin_enc,ron_enc &&
+  cargo doc   --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
 env:
   global:
   - secure: RFX1Ke3uk8ZdrAGwKPP7FXqQfC6bkGMDzV5ut9s5da6ClvoafosJF4RBvXi5j8KhQP9Kyow7Z8IwtTExNHMIjlE0MguHsYdFBdkj9HdjrqBQHThx5vMOq3VY3bNq9ah83Q6idoTTpQvoZ380BSHznHz8E3rmKGbEA0Z1NigWlT8DFfgqI5nTa64/bvD8IzMTjkLax4pq1SjsG8v+UgwNxkuYE6Yl/mpQJ/xTCGYiFHLKk4EW8z2I5DcK/XqY+w42uFDP2BRvXdzuS937A0lGZtAiK3sKJCBDq/2Ulkz4+onkAo9QT0k9Eea9dSoxXDk3RJHzDb5wLANtubxAWyTKiyTlO3I81ogPmHevSv3xDXXwLBjPxwwIRI1qt/01Nod4yIT4fWfIxcW+rY/W5P4v5QbvAJ079v8be1lnwCEFP55WXfTFEypvKUmNpCTeY9nAKiLywpQuibi/TuHmVH+R9xWlJaXrJ8+fM+dkl57V7AnIKs3nnYmE/c5guUakJ46QVZZtSQRcFfD0QeZPM5WaqAjiZ52eP4y/Mi5Rjg4/noLjXoR3YWYxWZsT5b7U2hv/wEMTzERgHev3aPZttO7gr3ug/FDv0TP6PKPCLd/i+g0w4RKRGArcAXIBWHdeEhfOYuC8Q93gl3d/qutvgGdWF4sdBpaPRcwmaWD+FoEWjWQ=

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,21 @@ matrix:
   include:
     # Linux
     - env: TARGET=i686-unknown-linux-gnu
-    - env: TARGET=i686-unknown-linux-musl NO_DYLIB=1
+    - env: TARGET=i686-unknown-linux-musl
     - env: TARGET=x86_64-unknown-linux-gnu
-    - env: TARGET=x86_64-unknown-linux-musl NO_DYLIB=1
+    - env: TARGET=x86_64-unknown-linux-musl
     - env: TARGET=i586-unknown-linux-gnu
 
     # iOS
-    - env: TARGET=aarch64-apple-ios DISABLE_TESTS=1 NO_DYLIB=1
+    - env: TARGET=aarch64-apple-ios DISABLE_TESTS=1
       os: osx
-    - env: TARGET=armv7-apple-ios DISABLE_TESTS=1 NO_DYLIB=1
+    - env: TARGET=armv7-apple-ios DISABLE_TESTS=1
       os: osx
-    - env: TARGET=armv7s-apple-ios DISABLE_TESTS=1 NO_DYLIB=1
+    - env: TARGET=armv7s-apple-ios DISABLE_TESTS=1
       os: osx
-    - env: TARGET=i386-apple-ios DISABLE_TESTS=1 NO_DYLIB=1
+    - env: TARGET=i386-apple-ios DISABLE_TESTS=1
       os: osx
-    - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1 NO_DYLIB=1
+    - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1
       os: osx
 
     # OSX

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,49 +12,49 @@ matrix:
     # iOS
     - env: TARGET=aarch64-apple-ios DISABLE_TESTS=1
       os: osx
-    - env: TARGET=armv7-apple-ios DISABLE_TESTS=1
-      os: osx
-    - env: TARGET=armv7s-apple-ios DISABLE_TESTS=1
-      os: osx
-    - env: TARGET=i386-apple-ios DISABLE_TESTS=1
-      os: osx
-    - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1
-      os: osx
+#   - env: TARGET=armv7-apple-ios DISABLE_TESTS=1
+#     os: osx
+#   - env: TARGET=armv7s-apple-ios DISABLE_TESTS=1
+#     os: osx
+#   - env: TARGET=i386-apple-ios DISABLE_TESTS=1
+#     os: osx
+#   - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1
+#     os: osx
 
-    # OSX
-    - env: TARGET=i686-apple-darwin
-      os: osx
-    - env: TARGET=x86_64-apple-darwin
-      os: osx
+#   # OSX
+#   - env: TARGET=i686-apple-darwin
+#     os: osx
+#   - env: TARGET=x86_64-apple-darwin
+#     os: osx
 
-    # New Architectures
+#   # New Architectures
     - env: TARGET=arm-unknown-linux-gnueabi DISABLE_TESTS=1
     - env: TARGET=armv7-unknown-linux-gnueabihf
-    - env: TARGET=sparc64-unknown-linux-gnu DISABLE_TESTS=1
+#   - env: TARGET=sparc64-unknown-linux-gnu DISABLE_TESTS=1
 
-    # arm
-    - env: TARGET=arm-unknown-linux-musleabi DISABLE_TESTS=1
-    - env: TARGET=armv7-unknown-linux-musleabihf DISABLE_TESTS=1
-    - env: TARGET=i586-unknown-linux-musl
-    - env: TARGET=armv5te-unknown-linux-gnueabi
+#   # arm
+#   - env: TARGET=arm-unknown-linux-musleabi DISABLE_TESTS=1
+#   - env: TARGET=armv7-unknown-linux-musleabihf DISABLE_TESTS=1
+#   - env: TARGET=i586-unknown-linux-musl
+#   - env: TARGET=armv5te-unknown-linux-gnueabi
 
-    # *BSD
-    - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
-    - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
-    - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
+#   # *BSD
+#   - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
+#   - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
+#   - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
 
-    # Other architectures
-    - env: TARGET=aarch64-unknown-linux-gnu
-    - env: TARGET=mips-unknown-linux-gnu
-    - env: TARGET=mips64-unknown-linux-gnuabi64
-    - env: TARGET=mips64el-unknown-linux-gnuabi64
-    - env: TARGET=mipsel-unknown-linux-gnu
-    - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
-    - env: TARGET=powerpc64-unknown-linux-gnu
-    - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
+#   # Other architectures
+#   - env: TARGET=aarch64-unknown-linux-gnu
+#   - env: TARGET=mips-unknown-linux-gnu
+#   - env: TARGET=mips64-unknown-linux-gnuabi64
+#   - env: TARGET=mips64el-unknown-linux-gnuabi64
+#   - env: TARGET=mipsel-unknown-linux-gnu
+#   - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
+#   - env: TARGET=powerpc64-unknown-linux-gnu
+#   - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
 
-    # Will probably fail due to LLVM 6
-    - env: TARGET=powerpc64le-unknown-linux-gnu
+#   # Will probably fail due to LLVM 6
+#   - env: TARGET=powerpc64le-unknown-linux-gnu
 
     # Testing other channels
     - env: TARGET=x86_64-unknown-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,10 +67,49 @@ matrix:
     - env: TARGET=x86_64-apple-darwin
       os: osx
       rust: nightly
+
+before_install:
+  - set -e
+  - rustup self update
+
+install:
+  - |
+    case $TARGET in
+        aarch64-apple-ios)
+            rustup target install $TARGET
+            ;;
+        armv7-apple-ios)
+            rustup target install $TARGET
+            ;;
+        armv7s-apple-ios)
+            rustup target install $TARGET
+            ;;
+        i386-apple-ios)
+            rustup target install $TARGET
+            ;;
+        x86_64-apple-ios)
+            rustup target install $TARGET
+            ;;
+        wasm32-unknown-unknown)
+            rustup target install $TARGET
+            ;;
+        x86_64-unknown-linux-gnux32)
+            rustup target install $TARGET
+            ;;
+        i586-unknown-linux-musl)
+            rustup target install $TARGET
+            ;;
+        armv5te-unknown-linux-gnueabi)
+            rustup target install $TARGET
+            ;;
+    esac
+    source ~/.cargo/env || true
+
 script:
   - cargo build --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
   - [[ $DISABLE_TESTS -eq 0 ]] && cargo test --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
   - cargo doc --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
+
 env:
   global:
   - secure: RFX1Ke3uk8ZdrAGwKPP7FXqQfC6bkGMDzV5ut9s5da6ClvoafosJF4RBvXi5j8KhQP9Kyow7Z8IwtTExNHMIjlE0MguHsYdFBdkj9HdjrqBQHThx5vMOq3VY3bNq9ah83Q6idoTTpQvoZ380BSHznHz8E3rmKGbEA0Z1NigWlT8DFfgqI5nTa64/bvD8IzMTjkLax4pq1SjsG8v+UgwNxkuYE6Yl/mpQJ/xTCGYiFHLKk4EW8z2I5DcK/XqY+w42uFDP2BRvXdzuS937A0lGZtAiK3sKJCBDq/2Ulkz4+onkAo9QT0k9Eea9dSoxXDk3RJHzDb5wLANtubxAWyTKiyTlO3I81ogPmHevSv3xDXXwLBjPxwwIRI1qt/01Nod4yIT4fWfIxcW+rY/W5P4v5QbvAJ079v8be1lnwCEFP55WXfTFEypvKUmNpCTeY9nAKiLywpQuibi/TuHmVH+R9xWlJaXrJ8+fM+dkl57V7AnIKs3nnYmE/c5guUakJ46QVZZtSQRcFfD0QeZPM5WaqAjiZ52eP4y/Mi5Rjg4/noLjXoR3YWYxWZsT5b7U2hv/wEMTzERgHev3aPZttO7gr3ug/FDv0TP6PKPCLd/i+g0w4RKRGArcAXIBWHdeEhfOYuC8Q93gl3d/qutvgGdWF4sdBpaPRcwmaWD+FoEWjWQ=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,72 @@
 sudo: false
 language: rust
-rust:
-- nightly
-- beta
-- stable
+matrix:
+  include:
+    # Linux
+    - env: TARGET=i686-unknown-linux-gnu
+    - env: TARGET=i686-unknown-linux-musl NO_DYLIB=1
+    - env: TARGET=x86_64-unknown-linux-gnu
+    - env: TARGET=x86_64-unknown-linux-musl NO_DYLIB=1
+    - env: TARGET=i586-unknown-linux-gnu
+
+    # iOS
+    - env: TARGET=aarch64-apple-ios DISABLE_TESTS=1 NO_DYLIB=1
+      os: osx
+    - env: TARGET=armv7-apple-ios DISABLE_TESTS=1 NO_DYLIB=1
+      os: osx
+    - env: TARGET=armv7s-apple-ios DISABLE_TESTS=1 NO_DYLIB=1
+      os: osx
+    - env: TARGET=i386-apple-ios DISABLE_TESTS=1 NO_DYLIB=1
+      os: osx
+    - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1 NO_DYLIB=1
+      os: osx
+
+    # OSX
+    - env: TARGET=i686-apple-darwin
+      os: osx
+    - env: TARGET=x86_64-apple-darwin
+      os: osx
+
+    # New Architectures
+    - env: TARGET=arm-unknown-linux-gnueabi DISABLE_TESTS=1
+    - env: TARGET=armv7-unknown-linux-gnueabihf
+    - env: TARGET=sparc64-unknown-linux-gnu DISABLE_TESTS=1
+
+    # arm
+    - env: TARGET=arm-unknown-linux-musleabi DISABLE_TESTS=1
+    - env: TARGET=armv7-unknown-linux-musleabihf DISABLE_TESTS=1
+    - env: TARGET=i586-unknown-linux-musl
+    - env: TARGET=armv5te-unknown-linux-gnueabi
+
+    # *BSD
+    - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
+    - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
+    - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
+
+    # Other architectures
+    - env: TARGET=aarch64-unknown-linux-gnu
+    - env: TARGET=mips-unknown-linux-gnu
+    - env: TARGET=mips64-unknown-linux-gnuabi64
+    - env: TARGET=mips64el-unknown-linux-gnuabi64
+    - env: TARGET=mipsel-unknown-linux-gnu
+    - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
+    - env: TARGET=powerpc64-unknown-linux-gnu
+    - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
+
+    # Will probably fail due to LLVM 6
+    - env: TARGET=powerpc64le-unknown-linux-gnu
+
+    # Testing other channels
+    - env: TARGET=x86_64-unknown-linux-gnu
+      rust: beta
+    - env: TARGET=x86_64-apple-darwin
+      os: osx
+      rust: beta
+    - env: TARGET=x86_64-unknown-linux-gnu
+      rust: nightly
+    - env: TARGET=x86_64-apple-darwin
+      os: osx
+      rust: nightly
 script:
 - |
   cargo build --features yaml_enc,bin_enc,ron_enc &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,59 +2,32 @@ sudo: false
 language: rust
 matrix:
   include:
-    # Linux
+    # TIER 1
+    - env: TARGET=i686-apple-darwin
+    - env: TARGET=i686-pc-windows-gnu
+    - env: TARGET=i686-pc-windows-msvc
     - env: TARGET=i686-unknown-linux-gnu
-    - env: TARGET=i686-unknown-linux-musl
+    - env: TARGET=x86_64-apple-darwin
+    - env: TARGET=x86_64-pc-windows-gnu
+    - env: TARGET=x86_64-pc-windows-msvc
     - env: TARGET=x86_64-unknown-linux-gnu
-    - env: TARGET=x86_64-unknown-linux-musl
-    - env: TARGET=i586-unknown-linux-gnu
 
-    # iOS
-    - env: TARGET=aarch64-apple-ios DISABLE_TESTS=1
-      os: osx
-#   - env: TARGET=armv7-apple-ios DISABLE_TESTS=1
-#     os: osx
-#   - env: TARGET=armv7s-apple-ios DISABLE_TESTS=1
-#     os: osx
-#   - env: TARGET=i386-apple-ios DISABLE_TESTS=1
-#     os: osx
-#   - env: TARGET=x86_64-apple-ios DISABLE_TESTS=1
-#     os: osx
-
-#   # OSX
-#   - env: TARGET=i686-apple-darwin
-#     os: osx
-#   - env: TARGET=x86_64-apple-darwin
-#     os: osx
-
-#   # New Architectures
-    - env: TARGET=arm-unknown-linux-gnueabi DISABLE_TESTS=1
+    # TIER 2 (where rustc and cargo are supported)
+    - env: TARGET=aarch64-unknown-linux-gnu
+    - env: TARGET=arm-unknown-linux-gnueabi
+    - env: TARGET=arm-unknown-linux-gnueabihf
     - env: TARGET=armv7-unknown-linux-gnueabihf
-#   - env: TARGET=sparc64-unknown-linux-gnu DISABLE_TESTS=1
-
-#   # arm
-#   - env: TARGET=arm-unknown-linux-musleabi DISABLE_TESTS=1
-#   - env: TARGET=armv7-unknown-linux-musleabihf DISABLE_TESTS=1
-#   - env: TARGET=i586-unknown-linux-musl
-#   - env: TARGET=armv5te-unknown-linux-gnueabi
-
-#   # *BSD
-#   - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
-#   - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
-#   - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
-
-#   # Other architectures
-#   - env: TARGET=aarch64-unknown-linux-gnu
-#   - env: TARGET=mips-unknown-linux-gnu
-#   - env: TARGET=mips64-unknown-linux-gnuabi64
-#   - env: TARGET=mips64el-unknown-linux-gnuabi64
-#   - env: TARGET=mipsel-unknown-linux-gnu
-#   - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
-#   - env: TARGET=powerpc64-unknown-linux-gnu
-#   - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
-
-#   # Will probably fail due to LLVM 6
-#   - env: TARGET=powerpc64le-unknown-linux-gnu
+    - env: TARGET=i686-unknown-freebsd
+    - env: TARGET=mips-unknown-linux-gnu
+    - env: TARGET=mips64-unknown-linux-gnuabi64
+    - env: TARGET=mips64el-unknown-linux-gnuabi64
+    - env: TARGET=mipsel-unknown-linux-gnu
+    - env: TARGET=powerpc-unknown-linux-gnu
+    - env: TARGET=powerpc64-unknown-linux-gnu
+    - env: TARGET=powerpc64le-unknown-linux-gnu
+    - env: TARGET=s390x-unknown-linux-gnu
+    - env: TARGET=x86_64-unknown-freebsd
+    - env: TARGET=x86_64-unknown-netbsd
 
     # Testing other channels
     - env: TARGET=x86_64-unknown-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,42 +73,43 @@ before_install:
   - rustup self update
 
 install:
-  - |
-    case $TARGET in
-        aarch64-apple-ios)
-            rustup target install $TARGET
-            ;;
-        armv7-apple-ios)
-            rustup target install $TARGET
-            ;;
-        armv7s-apple-ios)
-            rustup target install $TARGET
-            ;;
-        i386-apple-ios)
-            rustup target install $TARGET
-            ;;
-        x86_64-apple-ios)
-            rustup target install $TARGET
-            ;;
-        wasm32-unknown-unknown)
-            rustup target install $TARGET
-            ;;
-        x86_64-unknown-linux-gnux32)
-            rustup target install $TARGET
-            ;;
-        i586-unknown-linux-musl)
-            rustup target install $TARGET
-            ;;
-        armv5te-unknown-linux-gnueabi)
-            rustup target install $TARGET
-            ;;
-    esac
-    source ~/.cargo/env || true
+- |
+  case $TARGET in
+      aarch64-apple-ios)
+          rustup target install $TARGET
+          ;;
+      armv7-apple-ios)
+          rustup target install $TARGET
+          ;;
+      armv7s-apple-ios)
+          rustup target install $TARGET
+          ;;
+      i386-apple-ios)
+          rustup target install $TARGET
+          ;;
+      x86_64-apple-ios)
+          rustup target install $TARGET
+          ;;
+      wasm32-unknown-unknown)
+          rustup target install $TARGET
+          ;;
+      x86_64-unknown-linux-gnux32)
+          rustup target install $TARGET
+          ;;
+      i586-unknown-linux-musl)
+          rustup target install $TARGET
+          ;;
+      armv5te-unknown-linux-gnueabi)
+          rustup target install $TARGET
+          ;;
+  esac
+  source ~/.cargo/env || true
 
 script:
-  - cargo build --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
-  - [[ $DISABLE_TESTS -eq 0 ]] && cargo test --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
-  - cargo doc --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
+- |
+  cargo build --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
+  [[ $DISABLE_TESTS -eq 0 ]] && cargo test --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
+  cargo doc --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,10 +68,9 @@ matrix:
       os: osx
       rust: nightly
 script:
-- |
-  cargo build --target "$TARGET" --features yaml_enc,bin_enc,ron_enc &&
-  cargo test  --target "$TARGET" --features yaml_enc,bin_enc,ron_enc &&
-  cargo doc   --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
+  - cargo build --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
+  - [[ $DISABLE_TESTS -eq 0 ]] && cargo test --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
+  - cargo doc --target "$TARGET" --features yaml_enc,bin_enc,ron_enc
 env:
   global:
   - secure: RFX1Ke3uk8ZdrAGwKPP7FXqQfC6bkGMDzV5ut9s5da6ClvoafosJF4RBvXi5j8KhQP9Kyow7Z8IwtTExNHMIjlE0MguHsYdFBdkj9HdjrqBQHThx5vMOq3VY3bNq9ah83Q6idoTTpQvoZ380BSHznHz8E3rmKGbEA0Z1NigWlT8DFfgqI5nTa64/bvD8IzMTjkLax4pq1SjsG8v+UgwNxkuYE6Yl/mpQJ/xTCGYiFHLKk4EW8z2I5DcK/XqY+w42uFDP2BRvXdzuS937A0lGZtAiK3sKJCBDq/2Ulkz4+onkAo9QT0k9Eea9dSoxXDk3RJHzDb5wLANtubxAWyTKiyTlO3I81ogPmHevSv3xDXXwLBjPxwwIRI1qt/01Nod4yIT4fWfIxcW+rY/W5P4v5QbvAJ079v8be1lnwCEFP55WXfTFEypvKUmNpCTeY9nAKiLywpQuibi/TuHmVH+R9xWlJaXrJ8+fM+dkl57V7AnIKs3nnYmE/c5guUakJ46QVZZtSQRcFfD0QeZPM5WaqAjiZ52eP4y/Mi5Rjg4/noLjXoR3YWYxWZsT5b7U2hv/wEMTzERgHev3aPZttO7gr3ug/FDv0TP6PKPCLd/i+g0w4RKRGArcAXIBWHdeEhfOYuC8Q93gl3d/qutvgGdWF4sdBpaPRcwmaWD+FoEWjWQ=

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,35 +74,7 @@ before_install:
 
 install:
 - |
-  case $TARGET in
-      aarch64-apple-ios)
-          rustup target install $TARGET
-          ;;
-      armv7-apple-ios)
-          rustup target install $TARGET
-          ;;
-      armv7s-apple-ios)
-          rustup target install $TARGET
-          ;;
-      i386-apple-ios)
-          rustup target install $TARGET
-          ;;
-      x86_64-apple-ios)
-          rustup target install $TARGET
-          ;;
-      wasm32-unknown-unknown)
-          rustup target install $TARGET
-          ;;
-      x86_64-unknown-linux-gnux32)
-          rustup target install $TARGET
-          ;;
-      i586-unknown-linux-musl)
-          rustup target install $TARGET
-          ;;
-      armv5te-unknown-linux-gnueabi)
-          rustup target install $TARGET
-          ;;
-  esac
+  rustup target install $TARGET
   source ~/.cargo/env || true
 
 script:


### PR DESCRIPTION
This patch introduces CI tests on more targets than just travis standard.

It was taken from/inspired by
https://github.com/LiveSplit/livesplit-core/blob/master/.travis.yml
(which is MIT/Apache2 licensed)

---

Targets the rewrite to v2, so I don't waste any effort here to the "old" version! :smile: 

Lets see how this works out.