### PR TITLE
Add mmap based backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
 - stable
 env:
   global:
-    - FEATURES=yaml_enc,bin_enc,ron_enc
+    - FEATURES=yaml_enc,bin_enc,ron_enc,mmap
 script:
 - |
   cargo build --features $FEATURES &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ version = "1"
 optional = true
 version = "0.7"
 
+[dependencies.memmap]
+optional = true
+version = "0.6"
+
 [dev-dependencies]
 lazy_static = "1"
 serde_derive = "1"
@@ -43,4 +47,5 @@ default = []
 ron_enc = ["ron"]
 bin_enc = ["bincode", "base64"]
 yaml_enc = ["serde_yaml"]
+mmap = ["memmap"]
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ Usage
 Usage is quite simple:
 
 - Create/open a database using one of the Database constructors:
-    - Create a `FileDatabase` with `FileDatabase::from_path`
-    - Create a `MemoryDatabase` with `MemoryDatabase::memory`
-    - Create a `Database` with `Database::from_parts`
+    - Create a `FileDatabase` with `FileDatabase::from_path`.
+    - Create a `MemoryDatabase` with `MemoryDatabase::memory`.
+    - Create a `MmapDatabase` with `MmapDatabase::mmap` or `MmapDatabase::mmap_with_size` with `mmap` feature.
+    - Create a `Database` with `Database::from_parts`.
 - `Write`/`Read` data from the Database
 - Don't forget to run `save` periodically, or whenever it makes sense.
     - You can save in parallel to using the Database. However you will lock

--- a/src/backend/mmap.rs
+++ b/src/backend/mmap.rs
@@ -1,0 +1,151 @@
+extern crate memmap;
+extern crate failure;
+
+use self::failure::ResultExt;
+
+use super::Backend;
+
+use ::error;
+use ::std::io;
+use ::std::cmp;
+
+#[derive(Debug)]
+struct Mmap {
+    inner: memmap::MmapMut,
+    //End of data
+    pub end: usize,
+    //Mmap total len
+    pub len: usize
+}
+
+impl Mmap {
+    fn new(len: usize) -> io::Result<Self> {
+        let inner = memmap::MmapOptions::new().len(len).map_anon()?;
+
+        Ok(Self {
+            inner,
+            end: 0,
+            len
+        })
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.inner[..self.end]
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.inner[..self.end]
+    }
+
+    //Copies data to mmap and modifies data's end cursor.
+    fn write(&mut self, data: &[u8]) {
+        assert!(data.len() <= self.len);
+        self.end = data.len();
+        self.as_mut_slice().copy_from_slice(data);
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+
+    //Increases mmap size by max(old_size*2, new_size)
+    //Note that it doesn't copy original data
+    fn extend(&mut self, new_size: usize) -> io::Result<()> {
+        let len = cmp::max(self.len + self.len, new_size);
+        //Make sure we don't discard old mmap before creating new one;
+        let new_mmap = Self::new(len)?;
+        *self = new_mmap;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+/// A backend that uses anonymous mmap
+///
+/// The Backend automatically creates bigger map
+/// on demand using following strategy approach:
+///
+/// - If new data size allows, multiply size by 2.
+/// - Otherwise new data size
+///
+/// Note that mmap is never shrink back.
+///
+/// Use `Backend` methods to read and write into it.
+pub struct MmapStorage {
+    mmap: Mmap
+}
+
+impl MmapStorage {
+    #[inline]
+    ///Creates new storage with 1024b size.
+    pub fn new() -> error::Result<Self> {
+        Self::with_size(1024)
+    }
+
+    ///Creates new storage with custom size.
+    pub fn with_size(len: usize) -> error::Result<Self> {
+        let mmap = Mmap::new(len).context(error::RustbreakErrorKind::Backend)?;
+
+        Ok(Self {
+            mmap
+        })
+    }
+}
+
+impl Backend for MmapStorage {
+    fn get_data(&mut self) -> error::Result<Vec<u8>> {
+        let mmap = self.mmap.as_slice();
+        let mut buffer = Vec::with_capacity(mmap.len());
+        buffer.extend_from_slice(mmap);
+        Ok(buffer)
+    }
+
+    fn put_data(&mut self, data: &[u8]) -> error::Result<()> {
+        if self.mmap.len < data.len() {
+            self.mmap.extend(data.len()).context(error::RustbreakErrorKind::Backend)?;
+        }
+        self.mmap.write(data);
+        self.mmap.flush().context(error::RustbreakErrorKind::Backend)?;
+        Ok(())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::{Backend, MmapStorage};
+
+    #[test]
+    fn test_mmap_storage() {
+        let data = [4, 5, 1, 6, 8, 1];
+        let mut storage = MmapStorage::new().expect("To crate mmap storage");
+
+        storage.put_data(&data).expect("To put data");
+        assert_eq!(storage.mmap.end, data.len());
+        assert_eq!(storage.get_data().expect("To get data"), data);
+    }
+
+    #[test]
+    fn test_mmap_storage_extend() {
+        let data = [4, 5, 1, 6, 8, 1];
+        let mut storage = MmapStorage::with_size(4).expect("To crate mmap storage");
+
+        storage.put_data(&data).expect("To put data");
+        assert_eq!(storage.mmap.end, data.len());
+        assert_eq!(storage.mmap.len, 8);
+        assert_eq!(storage.get_data().expect("To get data"), data);
+    }
+
+    #[test]
+    fn test_mmap_storage_increase_by_new_data_size() {
+        let data = [4, 5, 1, 6, 8, 1];
+        let mut storage = MmapStorage::with_size(1).expect("To crate mmap storage");
+
+        storage.put_data(&data).expect("To put data");
+        assert_eq!(storage.mmap.end, data.len());
+        assert_eq!(storage.mmap.len, data.len());
+        assert_eq!(storage.get_data().expect("To get data"), data);
+    }
+
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -25,6 +25,11 @@ pub trait Backend {
     fn put_data(&mut self, data: &[u8]) -> error::Result<()>;
 }
 
+#[cfg(feature = "mmap")]
+mod mmap;
+#[cfg(feature = "mmap")]
+pub use self::mmap::MmapStorage;
+
 /// A backend using a file
 #[derive(Debug)]
 pub struct FileBackend(::std::fs::File);


### PR DESCRIPTION
This adds memory map based storage as alternative to plain`MemoryStorage`

Not sure what would you think about it so I'm wondering if you'd be ok with it and would it make sense?

I choose quite simple strategy for extending map by creating new one with new size `max(old_size*2, new_data_size)`