### PR TITLE
Transition to Rust edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 authors = ["Marcel Müller <neikos@neikos.email>"]
+categories = ["database-implementations"]
 description = "A modular and configurable database"
 documentation = "https://docs.rs/rustbreak"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["Marcel Müller <neikos@neikos.email>"]
 description = "A modular and configurable database"
 documentation = "https://docs.rs/rustbreak"
+edition = "2018"
 homepage = "https://github.com/TheNeikos/rustbreak"
 keywords = ["database", "simple", "fast", "rustbreak"]
 license = "MPL-2.0"

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -9,7 +9,7 @@
 // ```
 //
 
-extern crate rustbreak;
+
 #[macro_use] extern crate serde_derive;
 #[macro_use] extern crate lazy_static;
 

--- a/examples/full.rs
+++ b/examples/full.rs
@@ -1,6 +1,6 @@
-extern crate rustbreak;
+
 #[macro_use] extern crate serde_derive;
-extern crate failure;
+use failure;
 
 use rustbreak::FileDatabase;
 use rustbreak::deser::Ron;

--- a/examples/switching.rs
+++ b/examples/switching.rs
@@ -1,6 +1,6 @@
-extern crate rustbreak;
+
 #[macro_use] extern crate serde_derive;
-extern crate failure;
+use failure;
 
 use rustbreak::{FileDatabase, backend::FileBackend};
 use rustbreak::deser::{Ron, Yaml};

--- a/src/backend/mmap.rs
+++ b/src/backend/mmap.rs
@@ -4,7 +4,7 @@ use failure::ResultExt;
 
 use super::Backend;
 
-use error;
+use crate::error;
 
 use std::cmp;
 use std::io;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -11,7 +11,7 @@
 
 use failure::ResultExt;
 
-use error;
+use crate::error;
 
 /// The Backend Trait
 ///

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -82,13 +82,13 @@ impl FileBackend {
 /// An in memory backend
 ///
 /// It is backed by a `Vec<u8>`
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MemoryBackend(Vec<u8>);
 
 impl MemoryBackend {
     /// Construct a new Memory Database
     pub fn new() -> MemoryBackend {
-        MemoryBackend(vec![])
+        MemoryBackend::default()
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -28,10 +28,10 @@ pub trait Backend {
 #[cfg(feature = "mmap")]
 mod mmap;
 #[cfg(feature = "mmap")]
-pub use self::mmap::MmapStorage;
+pub use mmap::MmapStorage;
 
 mod path;
-pub use self::path::PathBackend;
+pub use path::PathBackend;
 
 /// A backend using a file
 #[derive(Debug)]

--- a/src/backend/path.rs
+++ b/src/backend/path.rs
@@ -6,8 +6,8 @@
 //! file system (with a path) and featuring atomic saves.
 
 use super::Backend;
-use ::error;
-use ::error::RustbreakErrorKind as ErrorKind;
+use crate::error;
+use crate::error::RustbreakErrorKind as ErrorKind;
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use failure::ResultExt;

--- a/src/backend/path.rs
+++ b/src/backend/path.rs
@@ -49,6 +49,7 @@ impl Backend for PathBackend {
     fn put_data(&mut self, data: &[u8]) -> error::Result<()> {
         use ::std::io::Write;
 
+        #[allow(clippy::or_fun_call)] // `Path::new` is a zero cost conversion
         let mut tempf = NamedTempFile::new_in(self.path.parent().unwrap_or(Path::new(".")))
             .context(ErrorKind::Backend)?;
         tempf.write_all(data).context(ErrorKind::Backend)?;

--- a/src/deser.rs
+++ b/src/deser.rs
@@ -88,8 +88,8 @@ mod ron {
     use ron::ser::PrettyConfig;
     use ron::de::from_reader as from_ron_string;
 
-    use error;
-    use deser::DeSerializer;
+    use crate::error;
+    use crate::deser::DeSerializer;
 
     /// The Struct that allows you to use `ron` the Rusty Object Notation
     #[derive(Debug, Default, Clone)]
@@ -116,8 +116,8 @@ mod yaml {
     use serde::de::DeserializeOwned;
     use failure::ResultExt;
 
-    use error;
-    use deser::DeSerializer;
+    use crate::error;
+    use crate::deser::DeSerializer;
 
     /// The struct that allows you to use yaml
     #[derive(Debug, Default, Clone)]
@@ -145,8 +145,8 @@ mod bincode {
     use serde::de::DeserializeOwned;
     use failure::ResultExt;
 
-    use error;
-    use deser::DeSerializer;
+    use crate::error;
+    use crate::deser::DeSerializer;
 
     /// The struct that allows you to use bincode
     #[derive(Debug, Default, Clone)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,7 +39,7 @@ pub struct RustbreakError {
 }
 
 impl Fail for RustbreakError {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.inner.cause()
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,8 +29,6 @@ pub enum RustbreakErrorKind {
     __Nonexhaustive,
 }
 
-
-
 /// The main error type that gets returned for errors that happen while interacting with a
 /// `Database`.
 #[derive(Debug)]
@@ -49,7 +47,7 @@ impl Fail for RustbreakError {
 }
 
 impl Display for RustbreakError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.inner, f)
     }
 }
@@ -69,7 +67,7 @@ impl From<RustbreakErrorKind> for RustbreakError {
 
 impl From<Context<RustbreakErrorKind>> for RustbreakError {
     fn from(inner: Context<RustbreakErrorKind>) -> RustbreakError {
-        RustbreakError { inner: inner }
+        RustbreakError { inner }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,26 +185,6 @@
 //! [failure]: https://boats.gitlab.io/failure/intro.html
 //! [features]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features
 
-
-extern crate serde;
-#[macro_use] extern crate failure;
-
-#[cfg(feature = "ron_enc")]
-extern crate ron;
-
-#[cfg(feature = "yaml_enc")]
-extern crate serde_yaml;
-
-#[cfg(feature = "bin_enc")]
-extern crate bincode;
-#[cfg(feature = "bin_enc")]
-extern crate base64;
-
-#[cfg(feature = "mmap")]
-extern crate memmap;
-
-extern crate tempfile;
-
 /// The rustbreak errors that can be returned
 pub mod error;
 pub mod backend;
@@ -574,7 +554,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         Database {
             data: RwLock::new(data),
             backend: Mutex::new(backend),
-            deser: deser,
+            deser,
         }
     }
 
@@ -759,7 +739,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer> {
         Database {
             backend: self.backend,
             data: self.data,
-            deser: deser,
+            deser,
         }
     }
 }
@@ -799,7 +779,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         Ok(Database {
             data: RwLock::new(convert(data)),
             backend: Mutex::new(backend),
-            deser: deser,
+            deser,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -668,6 +668,7 @@ impl<Data, DeSer> Database<Data, PathBackend, DeSer>
         where S: ToOwned<Owned=std::path::PathBuf>,
             std::path::PathBuf: std::borrow::Borrow<S>
     {
+        #[allow(clippy::redundant_clone)] // false positive
         let backend = PathBackend::open(path.to_owned())
             .context(error::RustbreakErrorKind::Backend)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,9 +212,9 @@ pub mod backend;
 pub mod deser;
 
 /// The `DeSerializer` trait used by serialization structs
-pub use deser::DeSerializer;
+pub use crate::deser::DeSerializer;
 /// The general error used by the Rustbreak Module
-pub use error::RustbreakError;
+pub use crate::error::RustbreakError;
 
 use std::sync::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::fmt::Debug;
@@ -223,9 +223,9 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use failure::ResultExt;
 
-use backend::{Backend, MemoryBackend, FileBackend, PathBackend};
+use crate::backend::{Backend, MemoryBackend, FileBackend, PathBackend};
 #[cfg(feature = "mmap")]
-use backend::MmapStorage;
+use crate::backend::MmapStorage;
 
 /// The Central Database to RustBreak
 ///


### PR DESCRIPTION
If you would like to transtition to rust edition 2018.
Transition to Rust edition 2018 and fix some clippy lints. See #71.
Fixes: issue #71