### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ tempfile = "3"
 
 [dependencies.ron]
 optional = true
-version = "0.2.0"
+version = "0.5"
 
 [dependencies.base64]
 optional = true
-version = "0.9.0"
+version = "0.11"
 
 [dependencies.bincode]
 optional = true
@@ -34,11 +34,11 @@ version = "1"
 
 [dependencies.serde_yaml]
 optional = true
-version = "0.7"
+version = "0.8.5"
 
 [dependencies.memmap]
 optional = true
-version = "0.6"
+version = "0.7"
 
 [dev-dependencies]
 lazy_static = "1"


### PR DESCRIPTION
Now `rustbreak` no longer depends on `serde_yaml` versions under 0.8.4,
which are vulnerable to uncontrolled recursion in deserialisation,
see [RUSTSEC-2018-0005](https://github.com/RustSec/advisory-db/blob/master/crates/serde_yaml/RUSTSEC-2018-0005.toml).

If you don't want to update all dependencies, please do update `serde_yaml` since the version currently used is vulnerable.

Maybe it would also be a good idea to run [`cargo audit`](https://github.com/RustSec/cargo-audit) in the ci to detect these things earlier.