### PR TITLE
Add many tests and fix the problems found

### DIFF
--- a/examples/config.rs
+++ b/examples/config.rs
@@ -9,14 +9,15 @@
 // ```
 //
 
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate lazy_static;
 
-#[macro_use] extern crate serde_derive;
-#[macro_use] extern crate lazy_static;
-
-use std::path::PathBuf;
-use std::default::Default;
-use rustbreak::FileDatabase;
 use rustbreak::deser::Ron;
+use rustbreak::FileDatabase;
+use std::default::Default;
+use std::path::PathBuf;
 
 type DB = FileDatabase<Config, Ron>;
 
@@ -45,12 +46,16 @@ impl Default for Config {
 }
 
 fn main() {
-    let _conf : Config = CONFIG.read(|conf| {
-        conf.clone()
-    }).expect("Reading configuration");
+    let _conf: Config = CONFIG
+        .read(|conf| conf.clone())
+        .expect("Reading configuration");
 
-    let (user_path, allow_overwrite) =
-        CONFIG.read(|conf| (conf.user_path.clone(), conf.allow_overwrite.clone())).expect("Read config");
+    let (user_path, allow_overwrite) = CONFIG
+        .read(|conf| (conf.user_path.clone(), conf.allow_overwrite.clone()))
+        .expect("Read config");
 
-    println!("The current configuration is: {:?} and {}", user_path, allow_overwrite);
+    println!(
+        "The current configuration is: {:?} and {}",
+        user_path, allow_overwrite
+    );
 }

--- a/examples/full.rs
+++ b/examples/full.rs
@@ -1,13 +1,14 @@
-
-#[macro_use] extern crate serde_derive;
+#[macro_use]
+extern crate serde_derive;
 use failure;
 
-use rustbreak::FileDatabase;
 use rustbreak::deser::Ron;
+use rustbreak::FileDatabase;
 
 #[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
 enum Country {
-    Italy, UnitedKingdom
+    Italy,
+    UnitedKingdom,
 }
 
 #[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -23,14 +24,20 @@ fn do_main() -> Result<(), failure::Error> {
 
     println!("Writing to Database");
     db.write(|db| {
-        db.insert("john".into(), Person {
-            name: String::from("John Andersson"),
-            country: Country::Italy
-        });
-        db.insert("fred".into(), Person {
-            name: String::from("Fred Johnson"),
-            country: Country::UnitedKingdom
-        });
+        db.insert(
+            "john".into(),
+            Person {
+                name: String::from("John Andersson"),
+                country: Country::Italy,
+            },
+        );
+        db.insert(
+            "fred".into(),
+            Person {
+                name: String::from("Fred Johnson"),
+                country: Country::UnitedKingdom,
+            },
+        );
         println!("Entries: \n{:#?}", db);
     })?;
 

--- a/examples/full.rs
+++ b/examples/full.rs
@@ -52,6 +52,6 @@ fn do_main() -> Result<(), failure::Error> {
 fn main() {
     if let Err(e) = do_main() {
         eprintln!("An error has occurred at: \n{}", e.backtrace());
-        ::std::process::exit(1);
+        std::process::exit(1);
     }
 }

--- a/examples/switching.rs
+++ b/examples/switching.rs
@@ -1,13 +1,14 @@
-
-#[macro_use] extern crate serde_derive;
+#[macro_use]
+extern crate serde_derive;
 use failure;
 
-use rustbreak::{FileDatabase, backend::FileBackend};
 use rustbreak::deser::{Ron, Yaml};
+use rustbreak::{backend::FileBackend, FileDatabase};
 
 #[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
 enum Country {
-    Italy, UnitedKingdom
+    Italy,
+    UnitedKingdom,
 }
 
 #[derive(Eq, PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -23,14 +24,20 @@ fn do_main() -> Result<(), failure::Error> {
 
     println!("Writing to Database");
     db.write(|db| {
-        db.insert("john".into(), Person {
-            name: String::from("John Andersson"),
-            country: Country::Italy
-        });
-        db.insert("fred".into(), Person {
-            name: String::from("Fred Johnson"),
-            country: Country::UnitedKingdom
-        });
+        db.insert(
+            "john".into(),
+            Person {
+                name: String::from("John Andersson"),
+                country: Country::Italy,
+            },
+        );
+        db.insert(
+            "fred".into(),
+            Person {
+                name: String::from("Fred Johnson"),
+                country: Country::UnitedKingdom,
+            },
+        );
         println!("Entries: \n{:#?}", db);
     })?;
 
@@ -39,7 +46,9 @@ fn do_main() -> Result<(), failure::Error> {
 
     // Now lets switch it
 
-    let db = db.with_deser(Yaml).with_backend(FileBackend::open("test.yml")?);
+    let db = db
+        .with_deser(Yaml)
+        .with_backend(FileBackend::open("test.yml")?);
     db.save()?;
 
     Ok(())
@@ -51,4 +60,3 @@ fn main() {
         std::process::exit(1);
     }
 }
-

--- a/examples/switching.rs
+++ b/examples/switching.rs
@@ -48,7 +48,7 @@ fn do_main() -> Result<(), failure::Error> {
 fn main() {
     if let Err(e) = do_main() {
         eprintln!("An error has occurred at: \n{}", e.backtrace());
-        ::std::process::exit(1);
+        std::process::exit(1);
     }
 }
 

--- a/src/backend/mmap.rs
+++ b/src/backend/mmap.rs
@@ -13,19 +13,14 @@ struct Mmap {
     /// End of data
     pub end: usize,
     /// Mmap total len
-    pub len: usize
+    pub len: usize,
 }
 
 impl Mmap {
     fn new(len: usize) -> io::Result<Self> {
-        let inner = memmap::MmapOptions::new().len(len)
-            .map_anon()?;
+        let inner = memmap::MmapOptions::new().len(len).map_anon()?;
 
-        Ok(Self {
-            inner,
-            end: 0,
-            len
-        })
+        Ok(Self { inner, end: 0, len })
     }
 
     fn as_slice(&self) -> &[u8] {
@@ -39,7 +34,9 @@ impl Mmap {
     /// Copies data to mmap and modifies data's end cursor.
     fn write(&mut self, data: &[u8]) -> Result<(), failure::Error> {
         if data.len() > self.len {
-            return Err(failure::err_msg("Unexpected write beyond mmap's backend capacity. This is a rustbreak's bug"));
+            return Err(failure::err_msg(
+                "Unexpected write beyond mmap's backend capacity. This is a rustbreak's bug",
+            ));
         }
         self.end = data.len();
         self.as_mut_slice().copy_from_slice(data);
@@ -75,7 +72,7 @@ impl Mmap {
 /// Use `Backend` methods to read and write into it.
 #[derive(Debug)]
 pub struct MmapStorage {
-    mmap: Mmap
+    mmap: Mmap,
 }
 
 impl MmapStorage {
@@ -88,9 +85,7 @@ impl MmapStorage {
     pub fn with_size(len: usize) -> error::Result<Self> {
         let mmap = Mmap::new(len).context(error::RustbreakErrorKind::Backend)?;
 
-        Ok(Self {
-            mmap
-        })
+        Ok(Self { mmap })
     }
 }
 
@@ -104,10 +99,16 @@ impl Backend for MmapStorage {
 
     fn put_data(&mut self, data: &[u8]) -> error::Result<()> {
         if self.mmap.len < data.len() {
-            self.mmap.resize_no_copy(data.len()).context(error::RustbreakErrorKind::Backend)?;
+            self.mmap
+                .resize_no_copy(data.len())
+                .context(error::RustbreakErrorKind::Backend)?;
         }
-        self.mmap.write(data).context(error::RustbreakErrorKind::Backend)?;
-        self.mmap.flush().context(error::RustbreakErrorKind::Backend)?;
+        self.mmap
+            .write(data)
+            .context(error::RustbreakErrorKind::Backend)?;
+        self.mmap
+            .flush()
+            .context(error::RustbreakErrorKind::Backend)?;
         Ok(())
     }
 }

--- a/src/backend/mmap.rs
+++ b/src/backend/mmap.rs
@@ -50,7 +50,7 @@ impl Mmap {
         self.inner.flush()
     }
 
-    /// Increases mmap size by max(old_size*2, new_size).
+    /// Increases mmap size by `max(old_size*2, new_size)`.
     ///
     /// Note that it doesn't copy original data
     fn resize_no_copy(&mut self, new_size: usize) -> io::Result<()> {

--- a/src/backend/mmap.rs
+++ b/src/backend/mmap.rs
@@ -117,6 +117,7 @@ mod tests {
     use super::{Backend, MmapStorage};
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_mmap_storage() {
         let data = [4, 5, 1, 6, 8, 1];
         let mut storage = MmapStorage::new().expect("To crate mmap storage");
@@ -127,6 +128,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_mmap_storage_extend() {
         let data = [4, 5, 1, 6, 8, 1];
         let mut storage = MmapStorage::with_size(4).expect("To crate mmap storage");
@@ -138,6 +140,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_mmap_storage_increase_by_new_data_size() {
         let data = [4, 5, 1, 6, 8, 1];
         let mut storage = MmapStorage::with_size(1).expect("To crate mmap storage");

--- a/src/backend/mmap.rs
+++ b/src/backend/mmap.rs
@@ -1,5 +1,3 @@
-use memmap;
-use failure;
 use failure::ResultExt;
 
 use super::Backend;
@@ -12,9 +10,9 @@ use std::io;
 #[derive(Debug)]
 struct Mmap {
     inner: memmap::MmapMut,
-    //End of data
+    /// End of data
     pub end: usize,
-    //Mmap total len
+    /// Mmap total len
     pub len: usize
 }
 
@@ -38,7 +36,7 @@ impl Mmap {
         &mut self.inner[..self.end]
     }
 
-    //Copies data to mmap and modifies data's end cursor.
+    /// Copies data to mmap and modifies data's end cursor.
     fn write(&mut self, data: &[u8]) -> Result<(), failure::Error> {
         if data.len() > self.len {
             return Err(failure::err_msg("Unexpected write beyond mmap's backend capacity. This is a rustbreak's bug"));
@@ -52,11 +50,12 @@ impl Mmap {
         self.inner.flush()
     }
 
-    //Increases mmap size by max(old_size*2, new_size)
-    //Note that it doesn't copy original data
+    /// Increases mmap size by max(old_size*2, new_size).
+    ///
+    /// Note that it doesn't copy original data
     fn resize_no_copy(&mut self, new_size: usize) -> io::Result<()> {
         let len = cmp::max(self.len + self.len, new_size);
-        //Make sure we don't discard old mmap before creating new one;
+        // Make sure we don't discard old mmap before creating new one;
         let new_mmap = Self::new(len)?;
         *self = new_mmap;
         Ok(())
@@ -80,12 +79,12 @@ pub struct MmapStorage {
 }
 
 impl MmapStorage {
-    ///Creates new storage with 1024 bytes
+    /// Creates new storage with 1024 bytes.
     pub fn new() -> error::Result<Self> {
         Self::with_size(1024)
     }
 
-    ///Creates new storage with custom size.
+    /// Creates new storage with custom size.
     pub fn with_size(len: usize) -> error::Result<Self> {
         let mmap = Mmap::new(len).context(error::RustbreakErrorKind::Backend)?;
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -4,10 +4,11 @@
 
 //! The persistence backends of the Database.
 //!
-//! A file is a `Backend` through the `FileBackend`, so is a `Vec<u8>` with a `MemoryBackend`.
+//! A file is a `Backend` through the `FileBackend`, so is a `Vec<u8>` with a
+//! `MemoryBackend`.
 //!
-//! Implementing your own Backend should be straightforward. Check the `Backend` documentation for
-//! details.
+//! Implementing your own Backend should be straightforward. Check the `Backend`
+//! documentation for details.
 
 use failure::ResultExt;
 
@@ -15,8 +16,9 @@ use crate::error;
 
 /// The Backend Trait.
 ///
-/// It should always read and save in full the data that it is passed. This means that a write to
-/// the backend followed by a read __must__ return the same dataset.
+/// It should always read and save in full the data that it is passed. This
+/// means that a write to the backend followed by a read __must__ return the
+/// same dataset.
 pub trait Backend {
     /// Read the all data from the backend.
     fn get_data(&mut self) -> error::Result<Vec<u8>>;
@@ -63,32 +65,50 @@ pub struct FileBackend(std::fs::File);
 
 impl Backend for FileBackend {
     fn get_data(&mut self) -> error::Result<Vec<u8>> {
-        use std::io::{Seek, SeekFrom, Read};
+        use std::io::{Read, Seek, SeekFrom};
 
         let mut buffer = vec![];
-        self.0.seek(SeekFrom::Start(0)).context(error::RustbreakErrorKind::Backend)?;
-        self.0.read_to_end(&mut buffer).context(error::RustbreakErrorKind::Backend)?;
+        self.0
+            .seek(SeekFrom::Start(0))
+            .context(error::RustbreakErrorKind::Backend)?;
+        self.0
+            .read_to_end(&mut buffer)
+            .context(error::RustbreakErrorKind::Backend)?;
         Ok(buffer)
     }
 
     fn put_data(&mut self, data: &[u8]) -> error::Result<()> {
         use std::io::{Seek, SeekFrom, Write};
 
-        self.0.seek(SeekFrom::Start(0)).context(error::RustbreakErrorKind::Backend)?;
-        self.0.set_len(0).context(error::RustbreakErrorKind::Backend)?;
-        self.0.write_all(data).context(error::RustbreakErrorKind::Backend)?;
-        self.0.sync_all().context(error::RustbreakErrorKind::Backend)?;
+        self.0
+            .seek(SeekFrom::Start(0))
+            .context(error::RustbreakErrorKind::Backend)?;
+        self.0
+            .set_len(0)
+            .context(error::RustbreakErrorKind::Backend)?;
+        self.0
+            .write_all(data)
+            .context(error::RustbreakErrorKind::Backend)?;
+        self.0
+            .sync_all()
+            .context(error::RustbreakErrorKind::Backend)?;
         Ok(())
     }
 }
 
 impl FileBackend {
-    /// Opens a new [`FileBackend`] for a given path, will create it if the file doesn't exist.
+    /// Opens a new [`FileBackend`] for a given path, will create it if the file
+    /// doesn't exist.
     pub fn open<P: AsRef<std::path::Path>>(path: P) -> error::Result<Self> {
         use std::fs::OpenOptions;
 
         Ok(Self(
-            OpenOptions::new().read(true).write(true).create(true).open(path).context(error::RustbreakErrorKind::Backend)?,
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open(path)
+                .context(error::RustbreakErrorKind::Backend)?,
         ))
     }
 
@@ -134,9 +154,9 @@ impl Backend for MemoryBackend {
 
 #[cfg(test)]
 mod tests {
+    use super::{Backend, FileBackend, MemoryBackend};
+    use std::io::{Read, Seek, SeekFrom};
     use tempfile;
-    use super::{Backend, MemoryBackend, FileBackend};
-    use std::io::{Seek, SeekFrom, Read};
 
     #[test]
     fn test_memory_backend() {
@@ -150,8 +170,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_file_backend_from_file() {
-        let file = tempfile::tempfile()
-            .expect("could not create temporary file");
+        let file = tempfile::tempfile().expect("could not create temporary file");
         let mut backend = FileBackend::from_file(file);
         let data = [4, 5, 1, 6, 8, 1];
         let data2 = [3, 99, 127, 6];
@@ -166,10 +185,8 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_file_backend_open_existing() {
-        let file = tempfile::NamedTempFile::new()
-            .expect("could not create temporary file");
-        let mut backend = FileBackend::open(file.path())
-            .expect("could not create backend");
+        let file = tempfile::NamedTempFile::new().expect("could not create temporary file");
+        let mut backend = FileBackend::open(file.path()).expect("could not create backend");
         let data = [4, 5, 1, 6, 8, 1];
 
         backend.put_data(&data).expect("could not put data");
@@ -179,12 +196,10 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_file_backend_open_new() {
-        let dir = tempfile::tempdir()
-            .expect("could not create temporary directory");
+        let dir = tempfile::tempdir().expect("could not create temporary directory");
         let mut file_path = dir.path().to_owned();
         file_path.push("rustbreak_file_db.db");
-        let mut backend = FileBackend::open(file_path)
-            .expect("could not create backend");
+        let mut backend = FileBackend::open(file_path).expect("could not create backend");
         let data = [4, 5, 1, 6, 8, 1];
 
         backend.put_data(&data).expect("could not put data");
@@ -195,8 +210,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_file_backend_into_inner() {
-        let file = tempfile::tempfile()
-            .expect("could not create temporary file");
+        let file = tempfile::tempfile().expect("could not create temporary file");
         let mut backend = FileBackend::from_file(file);
         let data = [4, 5, 1, 6, 8, 1];
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -84,18 +84,18 @@ impl Backend for FileBackend {
 
 impl FileBackend {
     /// Opens a new [`FileBackend`] for a given path, will create it if the file doesn't exist.
-    pub fn open<P: AsRef<std::path::Path>>(path: P) -> error::Result<FileBackend> {
+    pub fn open<P: AsRef<std::path::Path>>(path: P) -> error::Result<Self> {
         use std::fs::OpenOptions;
 
-        Ok(FileBackend(
+        Ok(Self(
             OpenOptions::new().read(true).write(true).create(true).open(path).context(error::RustbreakErrorKind::Backend)?,
         ))
     }
 
     /// Use an already open [`File`](std::fs::File) as the backend.
     #[must_use]
-    pub fn from_file(file: std::fs::File) -> FileBackend {
-        FileBackend(file)
+    pub fn from_file(file: std::fs::File) -> Self {
+        Self(file)
     }
 
     /// Return the inner File.
@@ -114,8 +114,8 @@ pub struct MemoryBackend(Vec<u8>);
 impl MemoryBackend {
     /// Construct a new Memory Database.
     #[must_use]
-    pub fn new() -> MemoryBackend {
-        MemoryBackend::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! The persistence backends of the Database
+//! The persistence backends of the Database.
 //!
 //! A file is a `Backend` through the `FileBackend`, so is a `Vec<u8>` with a `MemoryBackend`.
 //!
@@ -13,15 +13,15 @@ use failure::ResultExt;
 
 use crate::error;
 
-/// The Backend Trait
+/// The Backend Trait.
 ///
 /// It should always read and save in full the data that it is passed. This means that a write to
 /// the backend followed by a read __must__ return the same dataset.
 pub trait Backend {
-    /// Read the all data from the backend
+    /// Read the all data from the backend.
     fn get_data(&mut self) -> error::Result<Vec<u8>>;
 
-    /// Write the whole slice to the backend
+    /// Write the whole slice to the backend.
     fn put_data(&mut self, data: &[u8]) -> error::Result<()>;
 }
 
@@ -83,7 +83,7 @@ impl Backend for FileBackend {
 }
 
 impl FileBackend {
-    /// Opens a new FileBackend for a given path, will create it if the file doesn't exist.
+    /// Opens a new [`FileBackend`] for a given path, will create it if the file doesn't exist.
     pub fn open<P: AsRef<std::path::Path>>(path: P) -> error::Result<FileBackend> {
         use std::fs::OpenOptions;
 
@@ -92,25 +92,28 @@ impl FileBackend {
         ))
     }
 
-    /// Use an already open File as the backend
+    /// Use an already open [`File`](std::fs::File) as the backend.
+    #[must_use]
     pub fn from_file(file: std::fs::File) -> FileBackend {
         FileBackend(file)
     }
 
-    /// Return the inner File
+    /// Return the inner File.
+    #[must_use]
     pub fn into_inner(self) -> std::fs::File {
         self.0
     }
 }
 
-/// An in memory backend
+/// An in memory backend.
 ///
-/// It is backed by a `Vec<u8>`
+/// It is backed by a byte vector (`Vec<u8>`).
 #[derive(Debug, Default)]
 pub struct MemoryBackend(Vec<u8>);
 
 impl MemoryBackend {
-    /// Construct a new Memory Database
+    /// Construct a new Memory Database.
+    #[must_use]
     pub fn new() -> MemoryBackend {
         MemoryBackend::default()
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -148,6 +148,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_file_backend_from_file() {
         let file = tempfile::tempfile()
             .expect("could not create temporary file");
@@ -163,6 +164,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_file_backend_open_existing() {
         let file = tempfile::NamedTempFile::new()
             .expect("could not create temporary file");
@@ -175,6 +177,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_file_backend_open_new() {
         let dir = tempfile::tempdir()
             .expect("could not create temporary directory");
@@ -190,6 +193,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_file_backend_into_inner() {
         let file = tempfile::tempfile()
             .expect("could not create temporary file");

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -140,44 +140,61 @@ mod tests {
         let mut backend = MemoryBackend::new();
         let data = [4, 5, 1, 6, 8, 1];
 
-        backend.put_data(&data).unwrap();
-        assert_eq!(backend.get_data().unwrap(), data);
+        backend.put_data(&data).expect("could not put data");
+        assert_eq!(backend.get_data().expect("could not get data"), data);
     }
 
     #[test]
     fn test_file_backend_from_file() {
-        let file = tempfile::tempfile().unwrap();
+        let file = tempfile::tempfile()
+            .expect("could not create temporary file");
         let mut backend = FileBackend::from_file(file);
         let data = [4, 5, 1, 6, 8, 1];
         let data2 = [3, 99, 127, 6];
 
-        backend.put_data(&data).unwrap();
-        assert_eq!(backend.get_data().unwrap(), data);
+        backend.put_data(&data).expect("could not put data");
+        assert_eq!(backend.get_data().expect("could not get data"), data);
 
-        backend.put_data(&data2).unwrap();
-        assert_eq!(backend.get_data().unwrap(), data2);
+        backend.put_data(&data2).expect("could not put data");
+        assert_eq!(backend.get_data().expect("could not get data"), data2);
     }
 
     #[test]
-    fn test_file_backend_open() {
+    fn test_file_backend_open_existing() {
         let file = tempfile::NamedTempFile::new()
             .expect("could not create temporary file");
         let mut backend = FileBackend::open(file.path())
             .expect("could not create backend");
         let data = [4, 5, 1, 6, 8, 1];
 
-        backend.put_data(&data).unwrap();
-        assert_eq!(backend.get_data().unwrap(), data);
+        backend.put_data(&data).expect("could not put data");
+        assert_eq!(backend.get_data().expect("could not get data"), data);
+    }
+
+    #[test]
+    fn test_file_backend_open_new() {
+        let dir = tempfile::tempdir()
+            .expect("could not create temporary directory");
+        let mut file_path = dir.path().to_owned();
+        file_path.push("rustbreak_file_db.db");
+        let mut backend = FileBackend::open(file_path)
+            .expect("could not create backend");
+        let data = [4, 5, 1, 6, 8, 1];
+
+        backend.put_data(&data).expect("could not put data");
+        assert_eq!(backend.get_data().expect("could not get data"), data);
+        dir.close().expect("Error while deleting temp directory!");
     }
 
     #[test]
     fn test_file_backend_into_inner() {
-        let file = tempfile::tempfile().unwrap();
+        let file = tempfile::tempfile()
+            .expect("could not create temporary file");
         let mut backend = FileBackend::from_file(file);
         let data = [4, 5, 1, 6, 8, 1];
 
-        backend.put_data(&data).unwrap();
-        assert_eq!(backend.get_data().unwrap(), data);
+        backend.put_data(&data).expect("could not put data");
+        assert_eq!(backend.get_data().expect("could not get data"), data);
 
         let mut file = backend.into_inner();
         file.seek(SeekFrom::Start(0)).unwrap();

--- a/src/backend/path.rs
+++ b/src/backend/path.rs
@@ -65,6 +65,7 @@ mod tests {
     use super::{Backend, PathBackend};
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_path_backend_existing() {
         let file = NamedTempFile::new()
             .expect("could not create temporary file");
@@ -77,6 +78,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_path_backend_new() {
         let dir = tempfile::tempdir()
             .expect("could not create temporary directory");

--- a/src/backend/path.rs
+++ b/src/backend/path.rs
@@ -65,7 +65,7 @@ mod tests {
     use super::{Backend, PathBackend};
 
     #[test]
-    fn test_path_backend() {
+    fn test_path_backend_existing() {
         let file = NamedTempFile::new()
             .expect("could not create temporary file");
         let mut backend = PathBackend::open(file.path().to_owned())
@@ -74,5 +74,20 @@ mod tests {
 
         backend.put_data(&data).expect("could not put data");
         assert_eq!(backend.get_data().expect("could not get data"), data);
+    }
+
+    #[test]
+    fn test_path_backend_new() {
+        let dir = tempfile::tempdir()
+            .expect("could not create temporary directory");
+        let mut file_path = dir.path().to_owned();
+        file_path.push("rustbreak_path_db.db");
+        let mut backend = PathBackend::open(file_path)
+            .expect("could not create backend");
+        let data = [4, 5, 1, 6, 8, 1];
+
+        backend.put_data(&data).expect("could not put data");
+        assert_eq!(backend.get_data().expect("could not get data"), data);
+        dir.close().expect("Error while deleting temp directory!");
     }
 }

--- a/src/backend/path.rs
+++ b/src/backend/path.rs
@@ -33,7 +33,7 @@ impl PathBackend {
 
 impl Backend for PathBackend {
     fn get_data(&mut self) -> error::Result<Vec<u8>> {
-        use ::std::io::Read;
+        use std::io::Read;
 
         let mut file = OpenOptions::new().read(true)
             .open(self.path.as_path()).context(ErrorKind::Backend)?;
@@ -47,7 +47,7 @@ impl Backend for PathBackend {
     /// This won't corrupt the existing database file if the program panics
     /// during the save.
     fn put_data(&mut self, data: &[u8]) -> error::Result<()> {
-        use ::std::io::Write;
+        use std::io::Write;
 
         #[allow(clippy::or_fun_call)] // `Path::new` is a zero cost conversion
         let mut tempf = NamedTempFile::new_in(self.path.parent().unwrap_or(Path::new(".")))

--- a/src/deser.rs
+++ b/src/deser.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 use std::io::Read;
 
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 #[cfg(feature = "ron_enc")]
 pub use self::ron::Ron;
@@ -21,21 +21,22 @@ pub use self::bincode::Bincode;
 ///
 /// # Example
 ///
-/// For an imaginary serde compatible encoding scheme 'Frobnar', an example implementation can look
-/// like this:
+/// For an imaginary serde compatible encoding scheme 'Frobnar', an example
+/// implementation can look like this:
 ///
 /// ```rust
 /// extern crate rustbreak;
 /// extern crate serde;
-/// #[macro_use] extern crate failure;
+/// #[macro_use]
+/// extern crate failure;
 ///
-/// use std::io::Read;
-/// use serde::Serialize;
+/// use failure::{Backtrace, Context, Fail};
 /// use serde::de::Deserialize;
-/// use failure::{Context, Fail, Backtrace};
+/// use serde::Serialize;
+/// use std::io::Read;
 ///
-/// use rustbreak::error;
 /// use rustbreak::deser::DeSerializer;
+/// use rustbreak::error;
 ///
 /// #[derive(Fail, Debug)]
 /// #[fail(display = "A FrobnarError ocurred")]
@@ -53,7 +54,8 @@ pub use self::bincode::Bincode;
 /// struct Frobnar;
 ///
 /// impl<T: Serialize> DeSerializer<T> for Frobnar
-///     where for<'de> T: Deserialize<'de>
+/// where
+///     for<'de> T: Deserialize<'de>,
 /// {
 ///     fn serialize(&self, val: &T) -> Result<Vec<u8>, failure::Error> {
 ///         Ok(to_frobnar(val))
@@ -66,28 +68,29 @@ pub use self::bincode::Bincode;
 ///
 /// fn main() {}
 /// ```
-pub trait DeSerializer<T: Serialize + DeserializeOwned> : std::default::Default + Send + Sync + Clone {
+pub trait DeSerializer<T: Serialize + DeserializeOwned>:
+    std::default::Default + Send + Sync + Clone
+{
     /// Serializes a given value to a String
     fn serialize(&self, val: &T) -> Result<Vec<u8>, failure::Error>;
     /// Deserializes a String to a value
     fn deserialize<R: Read>(&self, s: R) -> Result<T, failure::Error>;
 }
 
-
 #[cfg(feature = "ron_enc")]
 mod ron {
     use std::io::Read;
 
-    use serde::Serialize;
-    use serde::de::DeserializeOwned;
     use failure::ResultExt;
+    use serde::de::DeserializeOwned;
+    use serde::Serialize;
 
+    use ron::de::from_reader as from_ron_string;
     use ron::ser::to_string_pretty as to_ron_string;
     use ron::ser::PrettyConfig;
-    use ron::de::from_reader as from_ron_string;
 
-    use crate::error;
     use crate::deser::DeSerializer;
+    use crate::error;
 
     /// The Struct that allows you to use `ron` the Rusty Object Notation
     #[derive(Debug, Default, Clone)]
@@ -95,7 +98,8 @@ mod ron {
 
     impl<T: Serialize + DeserializeOwned> DeSerializer<T> for Ron {
         fn serialize(&self, val: &T) -> Result<Vec<u8>, failure::Error> {
-            Ok(to_ron_string(val, PrettyConfig::default()).map(String::into_bytes)
+            Ok(to_ron_string(val, PrettyConfig::default())
+                .map(String::into_bytes)
                 .context(error::RustbreakErrorKind::Serialization)?)
         }
         fn deserialize<R: Read>(&self, s: R) -> Result<T, failure::Error> {
@@ -108,13 +112,13 @@ mod ron {
 mod yaml {
     use std::io::Read;
 
-    use serde_yaml::{to_string as to_yaml_string, from_reader as from_yaml_string};
-    use serde::Serialize;
-    use serde::de::DeserializeOwned;
     use failure::ResultExt;
+    use serde::de::DeserializeOwned;
+    use serde::Serialize;
+    use serde_yaml::{from_reader as from_yaml_string, to_string as to_yaml_string};
 
-    use crate::error;
     use crate::deser::DeSerializer;
+    use crate::error;
 
     /// The struct that allows you to use yaml
     #[derive(Debug, Default, Clone)]
@@ -137,12 +141,12 @@ mod bincode {
     use std::io::Read;
 
     use bincode::{deserialize_from, serialize};
-    use serde::Serialize;
-    use serde::de::DeserializeOwned;
     use failure::ResultExt;
+    use serde::de::DeserializeOwned;
+    use serde::Serialize;
 
-    use crate::error;
     use crate::deser::DeSerializer;
+    use crate::error;
 
     /// The struct that allows you to use bincode
     #[derive(Debug, Default, Clone)]

--- a/src/deser.rs
+++ b/src/deser.rs
@@ -66,7 +66,7 @@ pub use self::bincode::Bincode;
 ///
 /// fn main() {}
 /// ```
-pub trait DeSerializer<T: Serialize + DeserializeOwned> : ::std::default::Default + Send + Sync + Clone {
+pub trait DeSerializer<T: Serialize + DeserializeOwned> : std::default::Default + Send + Sync + Clone {
     /// Serializes a given value to a String
     fn serialize(&self, val: &T) -> Result<Vec<u8>, failure::Error>;
     /// Deserializes a String to a value

--- a/src/deser.rs
+++ b/src/deser.rs
@@ -78,7 +78,6 @@ pub trait DeSerializer<T: Serialize + DeserializeOwned> : ::std::default::Defaul
 mod ron {
     use std::io::Read;
 
-    use failure;
     use serde::Serialize;
     use serde::de::DeserializeOwned;
     use failure::ResultExt;
@@ -109,7 +108,6 @@ mod ron {
 mod yaml {
     use std::io::Read;
 
-    use failure;
     use serde_yaml::{to_string as to_yaml_string, from_reader as from_yaml_string};
     use serde::Serialize;
     use serde::de::DeserializeOwned;
@@ -138,7 +136,6 @@ mod yaml {
 mod bincode {
     use std::io::Read;
 
-    use failure;
     use bincode::{deserialize_from, serialize};
     use serde::Serialize;
     use serde::de::DeserializeOwned;

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ use failure::{Context, Fail, Backtrace};
 
 /// The different kinds of errors that can be returned
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+#[non_exhaustive]
 pub enum RustbreakErrorKind {
     /// A context error when a serialization failed
     #[fail(display = "Could not serialize the value")]
@@ -23,10 +24,6 @@ pub enum RustbreakErrorKind {
     /// If `Database::write_safe` is used and the closure panics, this error is returned
     #[fail(display = "The write operation paniced but got caught")]
     WritePanic,
-    /// This variant should never be used. It is meant to keep this enum forward compatible.
-    #[doc(hidden)]
-    #[fail(display = "You have found a secret message, please report it to the Rustbreak maintainer")]
-    __Nonexhaustive,
 }
 
 /// The main error type that gets returned for errors that happen while interacting with a

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use failure::{Backtrace, Context, Fail};
 use std::fmt::{self, Display};
-use failure::{Context, Fail, Backtrace};
 
 /// The different kinds of errors that can be returned
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
@@ -15,19 +15,21 @@ pub enum RustbreakErrorKind {
     /// A context error when a deserialization failed
     #[fail(display = "Could not deserialize the value")]
     Deserialization,
-    /// This error is returned if the `Database` is poisoned. See `Database::write` for details
+    /// This error is returned if the `Database` is poisoned. See
+    /// `Database::write` for details
     #[fail(display = "The database has been poisoned")]
     Poison,
     /// An error in the backend happened
     #[fail(display = "The backend has encountered an error")]
     Backend,
-    /// If `Database::write_safe` is used and the closure panics, this error is returned
+    /// If `Database::write_safe` is used and the closure panics, this error is
+    /// returned
     #[fail(display = "The write operation paniced but got caught")]
     WritePanic,
 }
 
-/// The main error type that gets returned for errors that happen while interacting with a
-/// `Database`.
+/// The main error type that gets returned for errors that happen while
+/// interacting with a `Database`.
 #[derive(Debug)]
 pub struct RustbreakError {
     inner: Context<RustbreakErrorKind>,
@@ -58,7 +60,9 @@ impl RustbreakError {
 
 impl From<RustbreakErrorKind> for RustbreakError {
     fn from(kind: RustbreakErrorKind) -> Self {
-        Self { inner: Context::new(kind) }
+        Self {
+            inner: Context::new(kind),
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,16 +57,16 @@ impl RustbreakError {
 }
 
 impl From<RustbreakErrorKind> for RustbreakError {
-    fn from(kind: RustbreakErrorKind) -> RustbreakError {
-        RustbreakError { inner: Context::new(kind) }
+    fn from(kind: RustbreakErrorKind) -> Self {
+        Self { inner: Context::new(kind) }
     }
 }
 
 impl From<Context<RustbreakErrorKind>> for RustbreakError {
-    fn from(inner: Context<RustbreakErrorKind>) -> RustbreakError {
-        RustbreakError { inner }
+    fn from(inner: Context<RustbreakErrorKind>) -> Self {
+        Self { inner }
     }
 }
 
 /// A simple type alias for errors
-pub type Result<T> = ::std::result::Result<T, RustbreakError>;
+pub type Result<T> = std::result::Result<T, RustbreakError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,7 +613,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// # }
     /// ```
     pub fn try_clone(&self) -> error::Result<MemoryDatabase<Data, DeSer>> {
-        let lock = self.data.write().map_err(|_| error::RustbreakErrorKind::Poison)?;
+        let lock = self.data.read().map_err(|_| error::RustbreakErrorKind::Poison)?;
 
         Ok(Database {
             data: RwLock::new(lock.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,51 +21,51 @@
     clippy::print_stdout,
     clippy::todo,
     clippy::unwrap_used,
-    clippy::wrong_pub_self_convention,
+    clippy::wrong_pub_self_convention
 )]
-
 #![warn(clippy::pedantic)]
-
 // part of `clippy::pedantic`, causing many warnings
-#![allow(
-    clippy::missing_errors_doc,
-    clippy::module_name_repetitions
-)]
+#![allow(clippy::missing_errors_doc, clippy::module_name_repetitions)]
 
 //! # Rustbreak
 //!
 //! Rustbreak was a [Daybreak][daybreak] inspired single file Database.
-//! It has now since evolved into something else. Please check v1 for a more similar version.
+//! It has now since evolved into something else. Please check v1 for a more
+//! similar version.
 //!
-//! You will find an overview here in the docs, but to give you a more complete tale of how this is
-//! used please check the [examples][examples].
+//! You will find an overview here in the docs, but to give you a more complete
+//! tale of how this is used please check the [examples][examples].
 //!
-//! At its core, Rustbreak is an attempt at making a configurable general-purpose store Database.
-//! It features the possibility of:
+//! At its core, Rustbreak is an attempt at making a configurable
+//! general-purpose store Database. It features the possibility of:
 //!
 //! - Choosing what kind of Data is stored in it
 //! - Which kind of Serialization is used for persistence
 //! - Which kind of persistence is used
 //!
-//! This means you can take any struct you can serialize and deserialize and stick it into this
-//! Database. It is then encoded with Ron, Yaml, JSON, Bincode, anything really that uses Serde
-//! operations!
+//! This means you can take any struct you can serialize and deserialize and
+//! stick it into this Database. It is then encoded with Ron, Yaml, JSON,
+//! Bincode, anything really that uses Serde operations!
 //!
-//! There are three helper type aliases [`MemoryDatabase`], [`FileDatabase`], and [`PathDatabase`], each backed by their
-//! respective backend.
+//! There are three helper type aliases [`MemoryDatabase`], [`FileDatabase`],
+//! and [`PathDatabase`], each backed by their respective backend.
 //!
-//! The [`MemoryBackend`] saves its data into a `Vec<u8>`, which is not that useful on its own, but
-//! is needed for compatibility with the rest of the Library.
+//! The [`MemoryBackend`] saves its data into a `Vec<u8>`, which is not that
+//! useful on its own, but is needed for compatibility with the rest of the
+//! Library.
 //!
-//! The [`FileDatabase`] is a classical file based database. You give it a path or a file, and it
-//! will use it as its storage. You still get to pick what encoding it uses.
+//! The [`FileDatabase`] is a classical file based database. You give it a path
+//! or a file, and it will use it as its storage. You still get to pick what
+//! encoding it uses.
 //!
-//! The [`PathDatabase`] is very similar, but always requires a path for creation. It features atomic
-//! saves, so that the old database contents won't be lost when panicing during the save. It
-//! should therefore be preferred to a [`FileDatabase`].
+//! The [`PathDatabase`] is very similar, but always requires a path for
+//! creation. It features atomic saves, so that the old database contents won't
+//! be lost when panicing during the save. It should therefore be preferred to a
+//! [`FileDatabase`].
 //!
-//! Using the [`Database::with_deser`] and [`Database::with_backend`] one can switch between the representations one needs.
-//! Even at runtime! However this is only useful in a few scenarios.
+//! Using the [`Database::with_deser`] and [`Database::with_backend`] one can
+//! switch between the representations one needs. Even at runtime! However this
+//! is only useful in a few scenarios.
 //!
 //! If you have any questions feel free to ask at the main [repo][repo].
 //!
@@ -84,7 +84,7 @@
 //! # extern crate failure;
 //! # extern crate rustbreak;
 //! # use std::collections::HashMap;
-//! use rustbreak::{MemoryDatabase, deser::Ron};
+//! use rustbreak::{deser::Ron, MemoryDatabase};
 //!
 //! # fn main() {
 //! # let func = || -> Result<(), failure::Error> {
@@ -111,7 +111,7 @@
 //! # extern crate failure;
 //! # extern crate rustbreak;
 //! # use std::collections::HashMap;
-//! use rustbreak::{MemoryDatabase, deser::Ron};
+//! use rustbreak::{deser::Ron, MemoryDatabase};
 //!
 //! # fn main() {
 //! # let func = || -> Result<(), failure::Error> {
@@ -133,20 +133,15 @@
 //!
 //! ## Error Handling
 //!
-//! Handling errors in Rustbreak is straightforward. Every `Result` has as its fail case as
-//! [`error::RustbreakError`]. This means that you can now either continue bubbling up said error
-//! case, or handle it yourself.
+//! Handling errors in Rustbreak is straightforward. Every `Result` has as its
+//! fail case as [`error::RustbreakError`]. This means that you can now either
+//! continue bubbling up said error case, or handle it yourself.
 //!
-//! You can simply call its `.kind()` method, giving you all the information you need to continue.
+//! You can simply call its `.kind()` method, giving you all the information you
+//! need to continue.
 //!
 //! ```rust
-//! use rustbreak::{
-//!     MemoryDatabase,
-//!     deser::Ron,
-//!     error::{
-//!         RustbreakError,
-//!     }
-//! };
+//! use rustbreak::{deser::Ron, error::RustbreakError, MemoryDatabase};
 //! let db = match MemoryDatabase::<usize, Ron>::memory(0) {
 //!     Ok(db) => db,
 //!     Err(e) => {
@@ -158,25 +153,29 @@
 //!
 //! ## Panics
 //!
-//! This Database implementation uses [`RwLock`] and [`Mutex`] under the hood. If either the closures
-//! given to [`Database::write`] or any of the Backend implementation methods panic the respective
-//! objects are then poisoned. This means that you *cannot panic* under any circumstances in your
-//! closures or custom backends.
+//! This Database implementation uses [`RwLock`] and [`Mutex`] under the hood.
+//! If either the closures given to [`Database::write`] or any of the Backend
+//! implementation methods panic the respective objects are then poisoned. This
+//! means that you *cannot panic* under any circumstances in your closures or
+//! custom backends.
 //!
-//! Currently there is no way to recover from a poisoned `Database` other than re-creating it.
+//! Currently there is no way to recover from a poisoned `Database` other than
+//! re-creating it.
 //!
 //! ## Examples
 //!
 //! There are several more or less in-depth example programs you can check out!
 //! Check them out here: [Examples][examples]
 //!
-//! - `config.rs` shows you how a possible configuration file could be managed with rustbreak
+//! - `config.rs` shows you how a possible configuration file could be managed
+//!   with rustbreak
 //! - `full.rs` shows you how the database can be used as a hashmap store
-//! - `switching.rs` show you how you can easily swap out different parts of the Database
-//!     *Note*: To run this example you need to enable the feature `yaml` like so:
-//!         `cargo run --example switching --features yaml`
-//! - `server/` is a fully fledged example app written with the Rocket framework to make a form of
-//!     micro-blogging website. You will need rust nightly to start it.
+//! - `switching.rs` show you how you can easily swap out different parts of the
+//!   Database *Note*: To run this example you need to enable the feature `yaml`
+//!   like so: `cargo run --example switching --features yaml`
+//! - `server/` is a fully fledged example app written with the Rocket framework
+//!   to make a form of micro-blogging website. You will need rust nightly to
+//!   start it.
 //!
 //! ## Features
 //!
@@ -187,8 +186,8 @@
 //! - `bin_enc` which enables the Bincode de/serialization
 //! - 'mmap' whhich enables memory map backend.
 //!
-//! [Enable them in your `Cargo.toml` file to use them.][features] You can safely have them all
-//! turned on per-default.
+//! [Enable them in your `Cargo.toml` file to use them.][features] You can
+//! safely have them all turned on per-default.
 //!
 //!
 //! [repo]: https://github.com/TheNeikos/rustbreak
@@ -198,11 +197,11 @@
 //! [failure]: https://boats.gitlab.io/failure/intro.html
 //! [features]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features
 
-/// The rustbreak errors that can be returned
-pub mod error;
 pub mod backend;
 /// Different serialization and deserialization methods one can use
 pub mod deser;
+/// The rustbreak errors that can be returned
+pub mod error;
 
 /// The `DeSerializer` trait used by serialization structs
 pub use crate::deser::DeSerializer;
@@ -213,13 +212,13 @@ use std::fmt::Debug;
 use std::ops::Deref;
 use std::sync::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use serde::Serialize;
-use serde::de::DeserializeOwned;
 use failure::ResultExt;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
-use crate::backend::{Backend, MemoryBackend, FileBackend, PathBackend};
 #[cfg(feature = "mmap")]
 use crate::backend::MmapStorage;
+use crate::backend::{Backend, FileBackend, MemoryBackend, PathBackend};
 
 /// The Central Database to Rustbreak.
 ///
@@ -227,41 +226,44 @@ use crate::backend::MmapStorage;
 ///
 /// - `Data`: Is the Data, you must specify this
 /// - `Back`: The storage backend.
-/// - `DeSer`: The Serializer/Deserializer or short `DeSer`. Check the [`deser`] module for other
-///     strategies.
+/// - `DeSer`: The Serializer/Deserializer or short `DeSer`. Check the [`deser`]
+///   module for other strategies.
 ///
 /// # Panics
 ///
-/// If the backend or the de/serialization panics, the database is poisoned. This means that any
-/// subsequent writes/reads will fail with an [`error::RustbreakErrorKind::Poison`].
-/// You can only recover from this by re-creating the Database Object.
+/// If the backend or the de/serialization panics, the database is poisoned.
+/// This means that any subsequent writes/reads will fail with an
+/// [`error::RustbreakErrorKind::Poison`]. You can only recover from this by
+/// re-creating the Database Object.
 #[derive(Debug)]
-pub struct Database<Data, Back, DeSer>
-{
+pub struct Database<Data, Back, DeSer> {
     data: RwLock<Data>,
     backend: Mutex<Back>,
-    deser: DeSer
+    deser: DeSer,
 }
 
 impl<Data, Back, DeSer> Database<Data, Back, DeSer>
-    where
-        Data: Serialize + DeserializeOwned + Clone + Send,
-        Back: Backend,
-        DeSer: DeSerializer<Data> + Send + Sync + Clone
+where
+    Data: Serialize + DeserializeOwned + Clone + Send,
+    Back: Backend,
+    DeSer: DeSerializer<Data> + Send + Sync + Clone,
 {
     /// Write lock the database and get write access to the `Data` container.
     ///
-    /// This gives you an exclusive lock on the memory object. Trying to open the database in
-    /// writing will block if it is currently being written to.
+    /// This gives you an exclusive lock on the memory object. Trying to open
+    /// the database in writing will block if it is currently being written
+    /// to.
     ///
     /// # Panics
     ///
-    /// If you panic in the closure, the database is poisoned. This means that any
-    /// subsequent writes/reads will fail with an [`error::RustbreakErrorKind::Poison`].
-    /// You can only recover from this by re-creating the Database Object.
+    /// If you panic in the closure, the database is poisoned. This means that
+    /// any subsequent writes/reads will fail with an
+    /// [`error::RustbreakErrorKind::Poison`]. You can only recover from
+    /// this by re-creating the Database Object.
     ///
-    /// If you do not have full control over the code being written, and cannot incur the cost of
-    /// having a single operation panicking then use [`Database::write_safe`].
+    /// If you do not have full control over the code being written, and cannot
+    /// incur the cost of having a single operation panicking then use
+    /// [`Database::write_safe`].
     ///
     /// # Examples
     ///
@@ -271,7 +273,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// # extern crate serde;
     /// # extern crate tempfile;
     /// # extern crate failure;
-    /// use rustbreak::{FileDatabase, deser::Ron};
+    /// use rustbreak::{deser::Ron, FileDatabase};
     ///
     /// #[derive(Debug, Serialize, Deserialize, Clone)]
     /// struct Data {
@@ -297,31 +299,37 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// # }
     /// ```
     pub fn write<T, R>(&self, task: T) -> error::Result<R>
-        where T: FnOnce(&mut Data) -> R
+    where
+        T: FnOnce(&mut Data) -> R,
     {
-        let mut lock = self.data.write().map_err(|_| error::RustbreakErrorKind::Poison)?;
+        let mut lock = self
+            .data
+            .write()
+            .map_err(|_| error::RustbreakErrorKind::Poison)?;
         Ok(task(&mut lock))
     }
 
-    /// Write lock the database and get write access to the `Data` container in a safe way.
+    /// Write lock the database and get write access to the `Data` container in
+    /// a safe way.
     ///
-    /// This gives you an exclusive lock on the memory object. Trying to open the database in
-    /// writing will block if it is currently being written to.
+    /// This gives you an exclusive lock on the memory object. Trying to open
+    /// the database in writing will block if it is currently being written
+    /// to.
     ///
-    /// This differs to `Database::write` in that a clone of the internal data is made, which is
-    /// then passed to the closure. Only if the closure doesn't panic is the internal model
-    /// updated.
+    /// This differs to `Database::write` in that a clone of the internal data
+    /// is made, which is then passed to the closure. Only if the closure
+    /// doesn't panic is the internal model updated.
     ///
-    /// Depending on the size of the database this can be very costly. This is a tradeoff to make
-    /// for panic safety.
+    /// Depending on the size of the database this can be very costly. This is a
+    /// tradeoff to make for panic safety.
     ///
     /// You should read the documentation about this:
     /// [`UnwindSafe`](https://doc.rust-lang.org/std/panic/trait.UnwindSafe.html)
     ///
     /// # Panics
     ///
-    /// When the closure panics, it is caught and a [`error::RustbreakErrorKind::WritePanic`] will be
-    /// returned.
+    /// When the closure panics, it is caught and a
+    /// [`error::RustbreakErrorKind::WritePanic`] will be returned.
     ///
     /// # Examples
     ///
@@ -332,12 +340,9 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// # extern crate tempfile;
     /// # extern crate failure;
     /// use rustbreak::{
-    ///     FileDatabase,
     ///     deser::Ron,
-    ///     error::{
-    ///         RustbreakError,
-    ///         RustbreakErrorKind,
-    ///     }
+    ///     error::{RustbreakError, RustbreakErrorKind},
+    ///     FileDatabase,
     /// };
     ///
     /// #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -350,10 +355,12 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// # let file = tempfile::tempfile()?;
     /// let db = FileDatabase::<Data, Ron>::from_file(file, Data { level: 0 })?;
     ///
-    /// let result = db.write_safe(|db| {
-    ///     db.level = 42;
-    ///     panic!("We panic inside the write code.");
-    /// }).expect_err("This should have been caught");
+    /// let result = db
+    ///     .write_safe(|db| {
+    ///         db.level = 42;
+    ///         panic!("We panic inside the write code.");
+    ///     })
+    ///     .expect_err("This should have been caught");
     ///
     /// match result.kind() {
     ///     RustbreakErrorKind::WritePanic => {
@@ -378,21 +385,26 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// # }
     /// ```
     pub fn write_safe<T>(&self, task: T) -> error::Result<()>
-        where T: FnOnce(&mut Data) + std::panic::UnwindSafe,
+    where
+        T: FnOnce(&mut Data) + std::panic::UnwindSafe,
     {
-        let mut lock = self.data.write().map_err(|_| error::RustbreakErrorKind::Poison)?;
+        let mut lock = self
+            .data
+            .write()
+            .map_err(|_| error::RustbreakErrorKind::Poison)?;
         let mut data = lock.clone();
         std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
             task(&mut data);
-        })).map_err(|_| error::RustbreakErrorKind::WritePanic)?;
+        }))
+        .map_err(|_| error::RustbreakErrorKind::WritePanic)?;
         *lock = data;
         Ok(())
     }
 
     /// Read lock the database and get read access to the `Data` container.
     ///
-    /// This gives you a read-only lock on the database. You can have as many readers in parallel
-    /// as you wish.
+    /// This gives you a read-only lock on the database. You can have as many
+    /// readers in parallel as you wish.
     ///
     /// # Errors
     ///
@@ -402,13 +414,18 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     ///
     /// # Panics
     ///
-    /// If you panic in the closure, the database is poisoned. This means that any
-    /// subsequent writes/reads will fail with an [`error::RustbreakErrorKind::Poison`].
-    /// You can only recover from this by re-creating the Database Object.
+    /// If you panic in the closure, the database is poisoned. This means that
+    /// any subsequent writes/reads will fail with an
+    /// [`error::RustbreakErrorKind::Poison`]. You can only recover from
+    /// this by re-creating the Database Object.
     pub fn read<T, R>(&self, task: T) -> error::Result<R>
-        where T: FnOnce(&Data) -> R
+    where
+        T: FnOnce(&Data) -> R,
     {
-        let mut lock = self.data.read().map_err(|_| error::RustbreakErrorKind::Poison)?;
+        let mut lock = self
+            .data
+            .read()
+            .map_err(|_| error::RustbreakErrorKind::Poison)?;
         Ok(task(&mut lock))
     }
 
@@ -425,7 +442,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// # extern crate serde;
     /// # extern crate tempfile;
     /// # extern crate failure;
-    /// use rustbreak::{FileDatabase, deser::Ron};
+    /// use rustbreak::{deser::Ron, FileDatabase};
     ///
     /// #[derive(Debug, Serialize, Deserialize, Clone)]
     /// struct Data {
@@ -450,21 +467,26 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// # }
     /// ```
     pub fn borrow_data<'a>(&'a self) -> error::Result<RwLockReadGuard<'a, Data>> {
-        self.data.read().map_err(|_| error::RustbreakErrorKind::Poison.into())
+        self.data
+            .read()
+            .map_err(|_| error::RustbreakErrorKind::Poison.into())
     }
 
     /// Write lock the database and get access to the underlying struct.
     ///
-    /// This gives you access to the underlying struct, allowing you to modify it.
+    /// This gives you access to the underlying struct, allowing you to modify
+    /// it.
     ///
     /// # Panics
     ///
-    /// If you panic while holding this reference, the database is poisoned. This means that any
-    /// subsequent writes/reads will fail with an [`error::RustbreakErrorKind::Poison`].
-    /// You can only recover from this by re-creating the Database Object.
+    /// If you panic while holding this reference, the database is poisoned.
+    /// This means that any subsequent writes/reads will fail with an
+    /// [`error::RustbreakErrorKind::Poison`]. You can only recover from
+    /// this by re-creating the Database Object.
     ///
-    /// If you do not have full control over the code being written, and cannot incur the cost of
-    /// having a single operation panicking then use [`Database::write_safe`].
+    /// If you do not have full control over the code being written, and cannot
+    /// incur the cost of having a single operation panicking then use
+    /// [`Database::write_safe`].
     ///
     /// # Examples
     ///
@@ -474,7 +496,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// # extern crate serde;
     /// # extern crate tempfile;
     /// # extern crate failure;
-    /// use rustbreak::{FileDatabase, deser::Ron};
+    /// use rustbreak::{deser::Ron, FileDatabase};
     ///
     /// #[derive(Debug, Serialize, Deserialize, Clone)]
     /// struct Data {
@@ -500,21 +522,34 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// # }
     /// ```
     pub fn borrow_data_mut<'a>(&'a self) -> error::Result<RwLockWriteGuard<'a, Data>> {
-        self.data.write().map_err(|_| error::RustbreakErrorKind::Poison.into())
+        self.data
+            .write()
+            .map_err(|_| error::RustbreakErrorKind::Poison.into())
     }
-
 
     /// Like [`Self::load`] but returns the write lock to data it used.
     fn load_get_data_lock(&self) -> error::Result<RwLockWriteGuard<'_, Data>> {
-        let mut backend_lock = self.backend.lock().map_err(|_| error::RustbreakErrorKind::Poison)?;
+        let mut backend_lock = self
+            .backend
+            .lock()
+            .map_err(|_| error::RustbreakErrorKind::Poison)?;
 
-        //let fresh_data = Self::inner_load(&mut backend_lock, &self.deser).context(error::RustbreakErrorKind::Backend)?;
-        let fresh_data = self.deser.deserialize(
-            &backend_lock.get_data().context(error::RustbreakErrorKind::Backend)?[..]
-        ).context(error::RustbreakErrorKind::Deserialization)?;
+        //let fresh_data = Self::inner_load(&mut backend_lock,
+        // &self.deser).context(error::RustbreakErrorKind::Backend)?;
+        let fresh_data = self
+            .deser
+            .deserialize(
+                &backend_lock
+                    .get_data()
+                    .context(error::RustbreakErrorKind::Backend)?[..],
+            )
+            .context(error::RustbreakErrorKind::Deserialization)?;
         drop(backend_lock);
 
-        let mut data_write_lock = self.data.write().map_err(|_| error::RustbreakErrorKind::Poison)?;
+        let mut data_write_lock = self
+            .data
+            .write()
+            .map_err(|_| error::RustbreakErrorKind::Poison)?;
         *data_write_lock = fresh_data;
         Ok(data_write_lock)
     }
@@ -525,32 +560,45 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     }
 
     /// Like [`Self::save`] but with explicit read (or write) lock to data.
-    fn save_data_locked<L: Deref<Target=Data>>(&self, lock: L) -> error::Result<()>
-        //where L::Target = Data
+    fn save_data_locked<L: Deref<Target = Data>>(&self, lock: L) -> error::Result<()>
+//where L::Target = Data
     {
-        let ser = self.deser.serialize(lock.deref())
-                    .context(error::RustbreakErrorKind::Serialization)?;
+        let ser = self
+            .deser
+            .serialize(lock.deref())
+            .context(error::RustbreakErrorKind::Serialization)?;
         drop(lock);
 
-        let mut backend = self.backend.lock().map_err(|_| error::RustbreakErrorKind::Poison)?;
-        backend.put_data(&ser).context(error::RustbreakErrorKind::Backend)?;
+        let mut backend = self
+            .backend
+            .lock()
+            .map_err(|_| error::RustbreakErrorKind::Poison)?;
+        backend
+            .put_data(&ser)
+            .context(error::RustbreakErrorKind::Backend)?;
         Ok(())
     }
 
     /// Flush the data structure to the backend.
     pub fn save(&self) -> error::Result<()> {
-        let data = self.data.read().map_err(|_| error::RustbreakErrorKind::Poison)?;
+        let data = self
+            .data
+            .read()
+            .map_err(|_| error::RustbreakErrorKind::Poison)?;
         self.save_data_locked(data)
     }
 
     /// Get a clone of the data as it is in memory right now.
     ///
-    /// To make sure you have the latest data, call this method with `load` true.
+    /// To make sure you have the latest data, call this method with `load`
+    /// true.
     pub fn get_data(&self, load: bool) -> error::Result<Data> {
         let data = if load {
             self.load_get_data_lock()?
         } else {
-            self.data.write().map_err(|_| error::RustbreakErrorKind::Poison)?
+            self.data
+                .write()
+                .map_err(|_| error::RustbreakErrorKind::Poison)?
         };
         Ok(data.clone())
     }
@@ -559,7 +607,10 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     ///
     /// To save the data afterwards, call with `save` true.
     pub fn put_data(&self, new_data: Data, save: bool) -> error::Result<()> {
-        let mut data = self.data.write().map_err(|_| error::RustbreakErrorKind::Poison)?;
+        let mut data = self
+            .data
+            .write()
+            .map_err(|_| error::RustbreakErrorKind::Poison)?;
         *data = new_data;
         if save {
             self.save_data_locked(data)
@@ -579,16 +630,22 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
 
     /// Break a database into its individual parts.
     pub fn into_inner(self) -> error::Result<(Data, Back, DeSer)> {
-        Ok((self.data.into_inner().map_err(|_| error::RustbreakErrorKind::Poison)?,
-            self.backend.into_inner().map_err(|_| error::RustbreakErrorKind::Poison)?,
-            self.deser))
+        Ok((
+            self.data
+                .into_inner()
+                .map_err(|_| error::RustbreakErrorKind::Poison)?,
+            self.backend
+                .into_inner()
+                .map_err(|_| error::RustbreakErrorKind::Poison)?,
+            self.deser,
+        ))
     }
 
     /// Tries to clone the Data in the Database.
     ///
     /// This method returns a `MemoryDatabase` which has an empty vector as a
-    /// backend initially. This means that the user is responsible for assigning a new backend
-    /// if an alternative is wanted.
+    /// backend initially. This means that the user is responsible for assigning
+    /// a new backend if an alternative is wanted.
     ///
     /// # Examples
     ///
@@ -598,7 +655,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// # extern crate serde;
     /// # extern crate tempfile;
     /// # extern crate failure;
-    /// use rustbreak::{FileDatabase, deser::Ron};
+    /// use rustbreak::{deser::Ron, FileDatabase};
     ///
     /// #[derive(Debug, Serialize, Deserialize, Clone)]
     /// struct Data {
@@ -628,7 +685,10 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// # }
     /// ```
     pub fn try_clone(&self) -> error::Result<MemoryDatabase<Data, DeSer>> {
-        let lock = self.data.read().map_err(|_| error::RustbreakErrorKind::Poison)?;
+        let lock = self
+            .data
+            .read()
+            .map_err(|_| error::RustbreakErrorKind::Poison)?;
 
         Ok(Database {
             data: RwLock::new(lock.clone()),
@@ -642,14 +702,14 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
 pub type FileDatabase<D, DS> = Database<D, FileBackend, DS>;
 
 impl<Data, DeSer> Database<Data, FileBackend, DeSer>
-    where
-        Data: Serialize + DeserializeOwned + Clone + Send,
-        DeSer: DeSerializer<Data> + Send + Sync + Clone
+where
+    Data: Serialize + DeserializeOwned + Clone + Send,
+    DeSer: DeSerializer<Data> + Send + Sync + Clone,
 {
     /// Create new [`FileDatabase`] from the file at [`Path`](std::path::Path).
-    pub fn from_path<S>(path: S, data: Data)
-        -> error::Result<Self>
-        where S: AsRef<std::path::Path>
+    pub fn from_path<S>(path: S, data: Data) -> error::Result<Self>
+    where
+        S: AsRef<std::path::Path>,
     {
         let backend = FileBackend::open(path).context(error::RustbreakErrorKind::Backend)?;
 
@@ -661,8 +721,7 @@ impl<Data, DeSer> Database<Data, FileBackend, DeSer>
     }
 
     /// Create new [`FileDatabase`] from a file.
-    pub fn from_file(file: std::fs::File, data: Data) -> error::Result<Self>
-    {
+    pub fn from_file(file: std::fs::File, data: Data) -> error::Result<Self> {
         let backend = FileBackend::from_file(file);
 
         Ok(Self {
@@ -677,19 +736,19 @@ impl<Data, DeSer> Database<Data, FileBackend, DeSer>
 pub type PathDatabase<D, DS> = Database<D, PathBackend, DS>;
 
 impl<Data, DeSer> Database<Data, PathBackend, DeSer>
-    where
-        Data: Serialize + DeserializeOwned + Clone + Send,
-        DeSer: DeSerializer<Data> + Send + Sync + Clone
+where
+    Data: Serialize + DeserializeOwned + Clone + Send,
+    DeSer: DeSerializer<Data> + Send + Sync + Clone,
 {
     /// Create new [`PathDatabase`] from a [`Path`](std::path::Path).
-    pub fn from_path<S>(path: S, data: Data)
-        -> error::Result<Self>
-        where S: ToOwned<Owned=std::path::PathBuf>,
-            std::path::PathBuf: std::borrow::Borrow<S>
+    pub fn from_path<S>(path: S, data: Data) -> error::Result<Self>
+    where
+        S: ToOwned<Owned = std::path::PathBuf>,
+        std::path::PathBuf: std::borrow::Borrow<S>,
     {
         #[allow(clippy::redundant_clone)] // false positive
-        let backend = PathBackend::open(path.to_owned())
-            .context(error::RustbreakErrorKind::Backend)?;
+        let backend =
+            PathBackend::open(path.to_owned()).context(error::RustbreakErrorKind::Backend)?;
 
         Ok(Self {
             data: RwLock::new(data),
@@ -703,9 +762,9 @@ impl<Data, DeSer> Database<Data, PathBackend, DeSer>
 pub type MemoryDatabase<D, DS> = Database<D, MemoryBackend, DS>;
 
 impl<Data, DeSer> Database<Data, MemoryBackend, DeSer>
-    where
-        Data: Serialize + DeserializeOwned + Clone + Send,
-        DeSer: DeSerializer<Data> + Send + Sync + Clone
+where
+    Data: Serialize + DeserializeOwned + Clone + Send,
+    DeSer: DeSerializer<Data> + Send + Sync + Clone,
 {
     /// Create new in-memory database.
     pub fn memory(data: Data) -> error::Result<Self> {
@@ -725,9 +784,9 @@ pub type MmapDatabase<D, DS> = Database<D, MmapStorage, DS>;
 
 #[cfg(feature = "mmap")]
 impl<Data, DeSer> Database<Data, MmapStorage, DeSer>
-    where
-        Data: Serialize + DeserializeOwned + Clone + Send,
-        DeSer: DeSerializer<Data> + Send + Sync + Clone
+where
+    Data: Serialize + DeserializeOwned + Clone + Send,
+    DeSer: DeSerializer<Data> + Send + Sync + Clone,
 {
     /// Create new [`MmapDatabase`].
     pub fn mmap(data: Data) -> error::Result<Self> {
@@ -754,8 +813,7 @@ impl<Data, DeSer> Database<Data, MmapStorage, DeSer>
 
 impl<Data, Back, DeSer> Database<Data, Back, DeSer> {
     /// Exchanges the `DeSerialization` strategy with the new one.
-    pub fn with_deser<T>(self, deser: T) -> Database<Data, Back, T>
-    {
+    pub fn with_deser<T>(self, deser: T) -> Database<Data, Back, T> {
         Database {
             backend: self.backend,
             data: self.data,
@@ -767,10 +825,9 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer> {
 impl<Data, Back, DeSer> Database<Data, Back, DeSer> {
     /// Exchanges the `Backend` with the new one.
     ///
-    /// The new backend does not necessarily have the latest data saved to it, so a `.save` should
-    /// be called to make sure that it is saved.
-    pub fn with_backend<T>(self, backend: T) -> Database<Data, T, DeSer>
-    {
+    /// The new backend does not necessarily have the latest data saved to it,
+    /// so a `.save` should be called to make sure that it is saved.
+    pub fn with_backend<T>(self, backend: T) -> Database<Data, T, DeSer> {
         Database {
             backend: Mutex::new(backend),
             data: self.data,
@@ -780,20 +837,22 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer> {
 }
 
 impl<Data, Back, DeSer> Database<Data, Back, DeSer>
-    where
-        Data: Serialize + DeserializeOwned + Clone + Send,
-        Back: Backend,
-        DeSer: DeSerializer<Data> + Send + Sync + Clone
+where
+    Data: Serialize + DeserializeOwned + Clone + Send,
+    Back: Backend,
+    DeSer: DeSerializer<Data> + Send + Sync + Clone,
 {
     /// Converts from one data type to another.
     ///
     /// This method is useful to migrate from one datatype to another.
-    pub fn convert_data<C, OutputData>(self, convert: C)
-        -> error::Result<Database<OutputData, Back, DeSer>>
-        where
-            OutputData: Serialize + DeserializeOwned + Clone + Send,
-            C: FnOnce(Data) -> OutputData,
-            DeSer: DeSerializer<OutputData> + Send + Sync,
+    pub fn convert_data<C, OutputData>(
+        self,
+        convert: C,
+    ) -> error::Result<Database<OutputData, Back, DeSer>>
+    where
+        OutputData: Serialize + DeserializeOwned + Clone + Send,
+        C: FnOnce(Data) -> OutputData,
+        DeSer: DeSerializer<OutputData> + Send + Sync,
     {
         let (data, backend, deser) = self.into_inner()?;
         Ok(Database {
@@ -822,18 +881,45 @@ mod tests {
     #[test]
     fn create_db_and_read() {
         let db = TestDb::memory(test_data()).expect("Could not create database");
-        assert_eq!("Hello World", db.read(|d| d.get(&1).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
-        assert_eq!("Rustbreak", db.read(|d| d.get(&100).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
+        assert_eq!(
+            "Hello World",
+            db.read(|d| d.get(&1).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Rustbreak",
+            db.read(|d| d.get(&100).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
     }
 
     #[test]
     fn write_twice() {
         let db = TestDb::memory(test_data()).expect("Could not create database");
-        db.write(|d| d.insert(3, "Write to db".to_string())).expect("Rustbreak write error");
-        db.write(|d| d.insert(3, "Second write".to_string())).expect("Rustbreak write error");
-        assert_eq!("Hello World", db.read(|d| d.get(&1).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
-        assert_eq!("Rustbreak", db.read(|d| d.get(&100).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
-        assert_eq!("Second write", db.read(|d| d.get(&3).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
+        db.write(|d| d.insert(3, "Write to db".to_string()))
+            .expect("Rustbreak write error");
+        db.write(|d| d.insert(3, "Second write".to_string()))
+            .expect("Rustbreak write error");
+        assert_eq!(
+            "Hello World",
+            db.read(|d| d.get(&1).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Rustbreak",
+            db.read(|d| d.get(&100).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Second write",
+            db.read(|d| d.get(&3).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
     }
 
     #[test]
@@ -842,28 +928,74 @@ mod tests {
         db.save().expect("Rustbreak save error");
         db.write(|d| d.clear()).expect("Rustbreak write error");
         db.load().expect("Rustbreak load error");
-        assert_eq!("Hello World", db.read(|d| d.get(&1).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
-        assert_eq!("Rustbreak", db.read(|d| d.get(&100).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
+        assert_eq!(
+            "Hello World",
+            db.read(|d| d.get(&1).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Rustbreak",
+            db.read(|d| d.get(&100).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
     }
 
     #[test]
     fn writesafe_twice() {
         let db = TestDb::memory(test_data()).expect("Could not create database");
-        db.write_safe(|d| {d.insert(3, "Write to db".to_string());}).expect("Rustbreak write error");
-        db.write_safe(|d| {d.insert(3, "Second write".to_string());}).expect("Rustbreak write error");
-        assert_eq!("Hello World", db.read(|d| d.get(&1).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
-        assert_eq!("Rustbreak", db.read(|d| d.get(&100).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
-        assert_eq!("Second write", db.read(|d| d.get(&3).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
+        db.write_safe(|d| {
+            d.insert(3, "Write to db".to_string());
+        })
+        .expect("Rustbreak write error");
+        db.write_safe(|d| {
+            d.insert(3, "Second write".to_string());
+        })
+        .expect("Rustbreak write error");
+        assert_eq!(
+            "Hello World",
+            db.read(|d| d.get(&1).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Rustbreak",
+            db.read(|d| d.get(&100).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Second write",
+            db.read(|d| d.get(&3).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
     }
 
     #[test]
     fn writesafe_panic() {
         let db = TestDb::memory(test_data()).expect("Could not create database");
-        let err = db.write_safe(|d| {d.clear(); panic!("Panic should be catched")}).expect_err("Did not error on panic in safe write!");
+        let err = db
+            .write_safe(|d| {
+                d.clear();
+                panic!("Panic should be catched")
+            })
+            .expect_err("Did not error on panic in safe write!");
         assert_eq!(crate::error::RustbreakErrorKind::WritePanic, err.kind());
 
-        assert_eq!("Hello World", db.read(|d| d.get(&1).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
-        assert_eq!("Rustbreak", db.read(|d| d.get(&100).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
+        assert_eq!(
+            "Hello World",
+            db.read(|d| d.get(&1).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Rustbreak",
+            db.read(|d| d.get(&100).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
     }
 
     #[test]
@@ -871,10 +1003,26 @@ mod tests {
         let db = TestDb::memory(test_data()).expect("Could not create database");
         let readlock1 = db.borrow_data().expect("Rustbreak readlock error");
         let readlock2 = db.borrow_data().expect("Rustbreak readlock error");
-        assert_eq!("Hello World", readlock1.get(&1).expect("Should be `Some` but was `None`"));
-        assert_eq!("Hello World", readlock2.get(&1).expect("Should be `Some` but was `None`"));
-        assert_eq!("Rustbreak", readlock1.get(&100).expect("Should be `Some` but was `None`"));
-        assert_eq!("Rustbreak", readlock2.get(&100).expect("Should be `Some` but was `None`"));
+        assert_eq!(
+            "Hello World",
+            readlock1.get(&1).expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Hello World",
+            readlock2.get(&1).expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Rustbreak",
+            readlock1
+                .get(&100)
+                .expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Rustbreak",
+            readlock2
+                .get(&100)
+                .expect("Should be `Some` but was `None`")
+        );
         assert_eq!(*readlock1, *readlock2);
     }
 
@@ -884,9 +1032,24 @@ mod tests {
         let mut writelock = db.borrow_data_mut().expect("Rustbreak writelock error");
         writelock.insert(3, "Write to db".to_string());
         drop(writelock);
-        assert_eq!("Hello World", db.read(|d| d.get(&1).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
-        assert_eq!("Rustbreak", db.read(|d| d.get(&100).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
-        assert_eq!("Write to db", db.read(|d| d.get(&3).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
+        assert_eq!(
+            "Hello World",
+            db.read(|d| d.get(&1).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Rustbreak",
+            db.read(|d| d.get(&100).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Write to db",
+            db.read(|d| d.get(&3).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
     }
 
     #[test]
@@ -909,8 +1072,18 @@ mod tests {
     fn put_data_mem() {
         let db = TestDb::memory(TestData::default()).expect("Could not create database");
         db.put_data(test_data(), false).expect("could not put data");
-        assert_eq!("Hello World", db.read(|d| d.get(&1).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
-        assert_eq!("Rustbreak", db.read(|d| d.get(&100).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
+        assert_eq!(
+            "Hello World",
+            db.read(|d| d.get(&1).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Rustbreak",
+            db.read(|d| d.get(&100).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
         let data = db.get_data(false).expect("could not get data");
         assert_eq!(test_data(), data);
     }
@@ -920,8 +1093,18 @@ mod tests {
         let db = TestDb::memory(TestData::default()).expect("Could not create database");
         db.put_data(test_data(), true).expect("could not put data");
         db.load().expect("Rustbreak load error");
-        assert_eq!("Hello World", db.read(|d| d.get(&1).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
-        assert_eq!("Rustbreak", db.read(|d| d.get(&100).cloned()).expect("Rustbreak read error").expect("Should be `Some` but was `None`"));
+        assert_eq!(
+            "Hello World",
+            db.read(|d| d.get(&1).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
+        assert_eq!(
+            "Rustbreak",
+            db.read(|d| d.get(&100).cloned())
+                .expect("Rustbreak read error")
+                .expect("Should be `Some` but was `None`")
+        );
         let data = db.get_data(false).expect("could not get data");
         assert_eq!(test_data(), data);
     }
@@ -930,10 +1113,13 @@ mod tests {
     fn save_and_into_inner() {
         let db = TestDb::memory(test_data()).expect("Could not create database");
         db.save().expect("Rustbreak save error");
-        let (data, mut backend, _) = db.into_inner().expect("error calling `Database.into_inner`");
+        let (data, mut backend, _) = db
+            .into_inner()
+            .expect("error calling `Database.into_inner`");
         assert_eq!(test_data(), data);
-        let parsed: TestData = ron::de::from_reader(&backend.get_data().expect("could not get data from backend")[..])
-            .expect("backend contains invalid RON");
+        let parsed: TestData =
+            ron::de::from_reader(&backend.get_data().expect("could not get data from backend")[..])
+                .expect("backend contains invalid RON");
         assert_eq!(test_data(), parsed);
     }
 
@@ -949,13 +1135,19 @@ mod tests {
 
     #[test]
     fn allow_databases_with_boxed_backend() {
-        let db = MemoryDatabase::<Vec<u64>, crate::deser::Ron>::memory(vec![]).expect("To be created");
-        let db: Database<_, Box<dyn Backend>, _>= db.with_backend(Box::new(MemoryBackend::new()));
-        db.put_data(vec![1, 2, 3], true).expect("Can save data in memory");
-        assert_eq!(&[1, 2, 3], &db.get_data(true).expect("Can get data from memory")[..]);
+        let db =
+            MemoryDatabase::<Vec<u64>, crate::deser::Ron>::memory(vec![]).expect("To be created");
+        let db: Database<_, Box<dyn Backend>, _> = db.with_backend(Box::new(MemoryBackend::new()));
+        db.put_data(vec![1, 2, 3], true)
+            .expect("Can save data in memory");
+        assert_eq!(
+            &[1, 2, 3],
+            &db.get_data(true).expect("Can get data from memory")[..]
+        );
     }
 
-    /// Since `save` only needs read-access to the data we should be able to save while holding a readlock.
+    /// Since `save` only needs read-access to the data we should be able to
+    /// save while holding a readlock.
     #[test]
     fn save_holding_readlock() {
         let db = TestDb::memory(test_data()).expect("Could not create database");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
     clippy::panic,
     clippy::print_stdout,
     clippy::todo,
-    clippy::unwrap_used,
+    //clippy::unwrap_used, // not yet in stable
     clippy::wrong_pub_self_convention
 )]
 #![warn(clippy::pedantic)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,19 @@
     unused_must_use,
     unused_mut,
     while_true,
+    clippy::panic,
+    clippy::print_stdout,
+    clippy::todo,
+    clippy::unwrap_used,
+    clippy::wrong_pub_self_convention,
+)]
+
+#![warn(clippy::pedantic)]
+
+// part of `clippy::pedantic`, causing many warnings
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::module_name_repetitions
 )]
 
 //! # Rustbreak
@@ -214,7 +227,7 @@ use crate::backend::MmapStorage;
 ///
 /// - `Data`: Is the Data, you must specify this
 /// - `Back`: The storage backend.
-/// - `DeSer`: The Serializer/Deserializer or short DeSer. Check the [`deser`] module for other
+/// - `DeSer`: The Serializer/Deserializer or short `DeSer`. Check the [`deser`] module for other
 ///     strategies.
 ///
 /// # Panics
@@ -490,14 +503,6 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         self.data.write().map_err(|_| error::RustbreakErrorKind::Poison.into())
     }
 
-//     // Now replaced by [`load_get_data_lock`].
-//     fn inner_load(backend: &mut Back, deser: &DeSer) -> error::Result<Data> {
-//         let new_data = deser.deserialize(
-//             &backend.get_data().context(error::RustbreakErrorKind::Backend)?[..]
-//         ).context(error::RustbreakErrorKind::Deserialization)?;
-//
-//         Ok(new_data)
-//     }
 
     /// Like [`Self::load`] but returns the write lock to data it used.
     fn load_get_data_lock(&self) -> error::Result<RwLockWriteGuard<'_, Data>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! saves, so that the old database contents won't be lost when panicing during the save. It
 //! should therefore be preferred to a [`FileDatabase`].
 //!
-//! Using the `with_deser` and `with_backend` one can switch between the representations one needs.
+//! Using the [`Database::with_deser`] and [`Database::with_backend`] one can switch between the representations one needs.
 //! Even at runtime! However this is only useful in a few scenarios.
 //!
 //! If you have any questions feel free to ask at the main [repo][repo].
@@ -121,7 +121,7 @@
 //! ## Error Handling
 //!
 //! Handling errors in Rustbreak is straightforward. Every `Result` has as its fail case as
-//! `error::RustbreakError`. This means that you can now either continue bubbling up said error
+//! [`error::RustbreakError`]. This means that you can now either continue bubbling up said error
 //! case, or handle it yourself.
 //!
 //! You can simply call its `.kind()` method, giving you all the information you need to continue.
@@ -145,8 +145,8 @@
 //!
 //! ## Panics
 //!
-//! This Database implementation uses `RwLock` and `Mutex` under the hood. If either the closures
-//! given to `Database::write` or any of the Backend implementation methods panic the respective
+//! This Database implementation uses [`RwLock`] and [`Mutex`] under the hood. If either the closures
+//! given to [`Database::write`] or any of the Backend implementation methods panic the respective
 //! objects are then poisoned. This means that you *cannot panic* under any circumstances in your
 //! closures or custom backends.
 //!
@@ -208,13 +208,13 @@ use crate::backend::{Backend, MemoryBackend, FileBackend, PathBackend};
 #[cfg(feature = "mmap")]
 use crate::backend::MmapStorage;
 
-/// The Central Database to RustBreak
+/// The Central Database to Rustbreak.
 ///
 /// It has 3 Type Generics:
 ///
-/// - Data: Is the Data, you must specify this
-/// - Back: The storage backend.
-/// - DeSer: The Serializer/Deserializer or short DeSer. Check the `deser` module for other
+/// - `Data`: Is the Data, you must specify this
+/// - `Back`: The storage backend.
+/// - `DeSer`: The Serializer/Deserializer or short DeSer. Check the [`deser`] module for other
 ///     strategies.
 ///
 /// # Panics
@@ -236,7 +236,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         Back: Backend,
         DeSer: DeSerializer<Data> + Send + Sync + Clone
 {
-    /// Write lock the database and get write access to the `Data` container
+    /// Write lock the database and get write access to the `Data` container.
     ///
     /// This gives you an exclusive lock on the memory object. Trying to open the database in
     /// writing will block if it is currently being written to.
@@ -290,7 +290,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         Ok(task(&mut lock))
     }
 
-    /// Write lock the database and get write access to the `Data` container in a safe way
+    /// Write lock the database and get write access to the `Data` container in a safe way.
     ///
     /// This gives you an exclusive lock on the memory object. Trying to open the database in
     /// writing will block if it is currently being written to.
@@ -303,7 +303,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     /// for panic safety.
     ///
     /// You should read the documentation about this:
-    /// [UnwindSafe](https://doc.rust-lang.org/std/panic/trait.UnwindSafe.html)
+    /// [`UnwindSafe`](https://doc.rust-lang.org/std/panic/trait.UnwindSafe.html)
     ///
     /// # Panics
     ///
@@ -376,7 +376,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         Ok(())
     }
 
-    /// Read lock the database and get read access to the `Data` container
+    /// Read lock the database and get read access to the `Data` container.
     ///
     /// This gives you a read-only lock on the database. You can have as many readers in parallel
     /// as you wish.
@@ -399,7 +399,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         Ok(task(&mut lock))
     }
 
-    /// Read lock the database and get access to the underlying struct
+    /// Read lock the database and get access to the underlying struct.
     ///
     /// This gives you access to the underlying struct, allowing for simple read
     /// only operations on it.
@@ -440,7 +440,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         self.data.read().map_err(|_| error::RustbreakErrorKind::Poison.into())
     }
 
-    /// Write lock the database and get access to the underlying struct
+    /// Write lock the database and get access to the underlying struct.
     ///
     /// This gives you access to the underlying struct, allowing you to modify it.
     ///
@@ -514,7 +514,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         Ok(data_write_lock)
     }
 
-    /// Load the Data from the backend
+    /// Load the data from the backend.
     pub fn load(&self) -> error::Result<()> {
         self.load_get_data_lock().map(|_| ())
     }
@@ -532,15 +532,15 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         Ok(())
     }
 
-    /// Flush the data structure to the backend
+    /// Flush the data structure to the backend.
     pub fn save(&self) -> error::Result<()> {
         let data = self.data.read().map_err(|_| error::RustbreakErrorKind::Poison)?;
         self.save_data_locked(data)
     }
 
-    /// Get a clone of the data as it is in memory right now
+    /// Get a clone of the data as it is in memory right now.
     ///
-    /// To make sure you have the latest data, call this method with `load` true
+    /// To make sure you have the latest data, call this method with `load` true.
     pub fn get_data(&self, load: bool) -> error::Result<Data> {
         let data = if load {
             self.load_get_data_lock()?
@@ -550,7 +550,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         Ok(data.clone())
     }
 
-    /// Puts the data as is into memory
+    /// Puts the data as is into memory.
     ///
     /// To save the data afterwards, call with `save` true.
     pub fn put_data(&self, new_data: Data, save: bool) -> error::Result<()> {
@@ -563,7 +563,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         }
     }
 
-    /// Create a database from its constituents
+    /// Create a database from its constituents.
     pub fn from_parts(data: Data, backend: Back, deser: DeSer) -> Database<Data, Back, DeSer> {
         Database {
             data: RwLock::new(data),
@@ -572,7 +572,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         }
     }
 
-    /// Break a database into its individual parts
+    /// Break a database into its individual parts.
     pub fn into_inner(self) -> error::Result<(Data, Back, DeSer)> {
         Ok((self.data.into_inner().map_err(|_| error::RustbreakErrorKind::Poison)?,
             self.backend.into_inner().map_err(|_| error::RustbreakErrorKind::Poison)?,
@@ -633,7 +633,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
     }
 }
 
-/// A database backed by a file
+/// A database backed by a file.
 pub type FileDatabase<D, DS> = Database<D, FileBackend, DS>;
 
 impl<Data, DeSer> Database<Data, FileBackend, DeSer>
@@ -641,7 +641,7 @@ impl<Data, DeSer> Database<Data, FileBackend, DeSer>
         Data: Serialize + DeserializeOwned + Clone + Send,
         DeSer: DeSerializer<Data> + Send + Sync + Clone
 {
-    /// Create new FileDatabase from Path
+    /// Create new [`FileDatabase`] from the file at [`Path`](std::path::Path).
     pub fn from_path<S>(path: S, data: Data)
         -> error::Result<FileDatabase<Data, DeSer>>
         where S: AsRef<std::path::Path>
@@ -655,7 +655,7 @@ impl<Data, DeSer> Database<Data, FileBackend, DeSer>
         })
     }
 
-    /// Create new FileDatabase from a file
+    /// Create new [`FileDatabase`] from a file.
     pub fn from_file(file: ::std::fs::File, data: Data) -> error::Result<FileDatabase<Data, DeSer>>
     {
         let backend = FileBackend::from_file(file);
@@ -694,7 +694,7 @@ impl<Data, DeSer> Database<Data, PathBackend, DeSer>
     }
 }
 
-/// A database backed by a `Vec<u8>`
+/// A database backed by a byte vector (`Vec<u8>`).
 pub type MemoryDatabase<D, DS> = Database<D, MemoryBackend, DS>;
 
 impl<Data, DeSer> Database<Data, MemoryBackend, DeSer>
@@ -702,7 +702,7 @@ impl<Data, DeSer> Database<Data, MemoryBackend, DeSer>
         Data: Serialize + DeserializeOwned + Clone + Send,
         DeSer: DeSerializer<Data> + Send + Sync + Clone
 {
-    /// Create new FileDatabase from Path
+    /// Create new in-memory database.
     pub fn memory(data: Data) -> error::Result<MemoryDatabase<Data, DeSer>> {
         let backend = MemoryBackend::new();
 
@@ -724,7 +724,7 @@ impl<Data, DeSer> Database<Data, MmapStorage, DeSer>
         Data: Serialize + DeserializeOwned + Clone + Send,
         DeSer: DeSerializer<Data> + Send + Sync + Clone
 {
-    /// Create new MmapDatabase.
+    /// Create new [`MmapDatabase`].
     pub fn mmap(data: Data) -> error::Result<MmapDatabase<Data, DeSer>> {
         let backend = MmapStorage::new()?;
 
@@ -735,7 +735,7 @@ impl<Data, DeSer> Database<Data, MmapStorage, DeSer>
         })
     }
 
-    /// Create new MmapDatabase with specified initial size.
+    /// Create new [`MmapDatabase`] with specified initial size.
     pub fn mmap_with_size(data: Data, size: usize) -> error::Result<MmapDatabase<Data, DeSer>> {
         let backend = MmapStorage::with_size(size)?;
 
@@ -748,7 +748,7 @@ impl<Data, DeSer> Database<Data, MmapStorage, DeSer>
 }
 
 impl<Data, Back, DeSer> Database<Data, Back, DeSer> {
-    /// Exchanges the DeSerialization strategy with the new one
+    /// Exchanges the `DeSerialization` strategy with the new one.
     pub fn with_deser<T>(self, deser: T) -> Database<Data, Back, T>
     {
         Database {
@@ -760,7 +760,7 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer> {
 }
 
 impl<Data, Back, DeSer> Database<Data, Back, DeSer> {
-    /// Exchanges the Backend with the new one
+    /// Exchanges the `Backend` with the new one.
     ///
     /// The new backend does not necessarily have the latest data saved to it, so a `.save` should
     /// be called to make sure that it is saved.
@@ -780,9 +780,9 @@ impl<Data, Back, DeSer> Database<Data, Back, DeSer>
         Back: Backend,
         DeSer: DeSerializer<Data> + Send + Sync + Clone
 {
-    /// Converts from one data type to another
+    /// Converts from one data type to another.
     ///
-    /// This method is useful to migrate from one datatype to another
+    /// This method is useful to migrate from one datatype to another.
     pub fn convert_data<C, OutputData>(self, convert: C)
         -> error::Result<Database<OutputData, Back, DeSer>>
         where

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -119,6 +119,17 @@ fn create_pathdb<S: DeSerializer<Data> + Debug>() -> PathDatabase<Data, S> {
 macro_rules! test_basic_save_load {
     ($name:ident, $db:expr, $enc:ty) => {
         #[test]
+        #[cfg_attr(miri, ignore)]
+        fn $name() {
+            let db: Database<Data, _, $enc> = $db;
+            test_basic_save_load(&db);
+            test_put_data(&db);
+            test_multi_borrow(&db);
+            test_convert_data(db);
+        }
+    };
+    ($name:ident, $db:expr, $enc:ty, miri=true) => {
+        #[test]
         fn $name() {
             let db: Database<Data, _, $enc> = $db;
             test_basic_save_load(&db);
@@ -137,9 +148,9 @@ test_basic_save_load! (filepath_ron, create_filedb_from_path(), Ron);
 test_basic_save_load! (filepath_yaml, create_filedb_from_path(), Yaml);
 test_basic_save_load! (filepath_bincode, create_filedb_from_path(), Bincode);
 
-test_basic_save_load! (mem_ron, create_memdb(), Ron);
-test_basic_save_load! (mem_yaml, create_memdb(), Yaml);
-test_basic_save_load! (mem_bincode, create_memdb(), Bincode);
+test_basic_save_load! (mem_ron, create_memdb(), Ron, miri=true);
+test_basic_save_load! (mem_yaml, create_memdb(), Yaml, miri=true);
+test_basic_save_load! (mem_bincode, create_memdb(), Bincode, miri=true);
 
 test_basic_save_load! (mmap_ron, create_mmapdb(), Ron);
 test_basic_save_load! (mmap_yaml, create_mmapdb(), Yaml);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,154 @@
+use rustbreak::{Database, FileDatabase, MemoryDatabase, MmapDatabase, PathDatabase};
+use rustbreak::backend::Backend;
+use rustbreak::deser::{DeSerializer, Ron, Yaml, Bincode};
+use std::fmt::Debug;
+use std::ops::Deref;
+use tempfile::tempfile;
+
+type Data = std::collections::HashMap<u64, String>;
+
+fn conv(mut data: Data) -> Data {
+    data.remove(&2);
+    data.insert(0, "Newly inserted".to_string());
+    data.insert(16, "Convertion succesful".to_string());
+    data
+}
+
+fn test_basic_save_load<B: Backend + Debug, S: DeSerializer<Data> + Debug>(db: &Database<Data, B, S>) {
+    db.write(|db| {db.insert(2, "Hello world!".to_string());})
+        .expect("rustbreak write error");
+    db.write_safe(|db| {db.insert(5, "Hello again".to_string());})
+        .expect("rustbreak write error");
+    db.save().expect("error while saving");
+    let saved_state = db.get_data(false).expect("could not get data");
+
+    // test that loading correctly restores the data
+    db.write(|db| {db.clear();})
+        .expect("rustbreak write error");
+    db.load().expect("rustbreak load error");
+
+    let len = db.read(|db| db.len()).expect("rustbreak read error");
+    assert_eq!(len, 2);
+
+    let second = db.read(|db| db.get(&2).cloned()).expect("rustbreak read error");
+    assert_eq!(second, Some(String::from("Hello world!")));
+
+    let fith = db.read(|db| db.get(&5).cloned()).expect("rustbreak read error");
+    assert_eq!(fith, Some(String::from("Hello again")));
+
+    let data = db.borrow_data().expect("rustbreak borrow error");
+    assert_eq!(&saved_state, data.deref());
+}
+
+fn test_multi_borrow<B: Backend + Debug, S: DeSerializer<Data> + Debug>(db: &Database<Data, B, S>) {
+    let data1 = db.borrow_data().expect("rustbreak borrow error");
+    let data2 = db.borrow_data().expect("rustbreak borrow error");
+    let data3 = db.borrow_data().expect("rustbreak borrow error");
+    assert_eq!(data1.deref(), data2.deref());
+    assert_eq!(data1.deref(), data3.deref());
+}
+
+fn test_put_data<B: Backend + Debug, S: DeSerializer<Data> + Debug>(db: &Database<Data, B, S>) {
+    let backup = db.get_data(true).expect("could not get data");
+
+    let mut other_state = Data::new();
+    other_state.insert(3, "Foo".to_string());
+    other_state.insert(7, "Bar".to_string());
+    other_state.insert(19, "Bazz".to_string());
+
+    db.put_data(other_state.clone(), true).expect("could not put data");
+    let data = db.borrow_data().expect("rustbreak borrow error");
+    assert_eq!(&other_state, data.deref());
+    // If we do not explicitly drop `data` here, the subsequent write will freeze
+    drop(data);
+
+    db.write(|db| {db.clear();})
+        .expect("rustbreak write error");
+    db.load().expect("rustbreak load error");
+
+    let data = db.borrow_data().expect("rustbreak borrow error");
+    assert_eq!(&other_state, data.deref());
+    drop(data);
+
+    db.put_data(backup, false).expect("could not put data");
+}
+
+fn test_convert_data<B: Backend + Debug, S: DeSerializer<Data> + Debug>(db: Database<Data, B, S>) {
+    let db = db.convert_data(conv).expect("Could not convert data");
+
+    let mut expected_state = Data::new();
+    expected_state.insert(0, "Newly inserted".to_string());
+    expected_state.insert(5, "Hello again".to_string());
+    expected_state.insert(16, "Convertion succesful".to_string());
+    assert_eq!(&expected_state, db.borrow_data().expect("rustbreak borrow error").deref());
+}
+
+fn create_filedb<S: DeSerializer<Data> + Debug>() -> FileDatabase<Data, S> {
+    FileDatabase::from_file(tempfile().expect("could not create file"), Data::default())
+        .expect("could not create database")
+}
+
+fn create_filedb_from_path<S: DeSerializer<Data> + Debug>() -> FileDatabase<Data, S> {
+    let file = tempfile::NamedTempFile::new()
+        .expect("could not create temporary file");
+    FileDatabase::from_path(file.path(), Data::default())
+        .expect("could not create database")
+}
+
+fn create_memdb<S: DeSerializer<Data> + Debug>() -> MemoryDatabase<Data, S> {
+    MemoryDatabase::memory(Data::default()).expect("could not create database")
+}
+
+fn create_mmapdb<S: DeSerializer<Data> + Debug>() -> MmapDatabase<Data, S> {
+    MmapDatabase::mmap(Data::default()).expect("could not create database")
+}
+
+fn create_mmapdb_with_size<S: DeSerializer<Data> + Debug>(size: usize) -> MmapDatabase<Data, S> {
+    MmapDatabase::mmap_with_size(Data::default(), size)
+        .expect("could not create database")
+}
+
+
+fn create_pathdb<S: DeSerializer<Data> + Debug>() -> PathDatabase<Data, S> {
+    let file = tempfile::NamedTempFile::new()
+        .expect("could not create temporary file");
+    PathDatabase::from_path(file.path().to_owned(), Data::default())
+        .expect("could not create database")
+}
+
+macro_rules! test_basic_save_load {
+    ($name:ident, $db:expr, $enc:ty) => {
+        #[test]
+        fn $name() {
+            let db: Database<Data, _, $enc> = $db;
+            test_basic_save_load(&db);
+            test_put_data(&db);
+            test_multi_borrow(&db);
+            test_convert_data(db);
+        }
+    };
+}
+
+test_basic_save_load! (file_ron, create_filedb(), Ron);
+test_basic_save_load! (file_yaml, create_filedb(), Yaml);
+test_basic_save_load! (file_bincode, create_filedb(), Bincode);
+
+test_basic_save_load! (filepath_ron, create_filedb_from_path(), Ron);
+test_basic_save_load! (filepath_yaml, create_filedb_from_path(), Yaml);
+test_basic_save_load! (filepath_bincode, create_filedb_from_path(), Bincode);
+
+test_basic_save_load! (mem_ron, create_memdb(), Ron);
+test_basic_save_load! (mem_yaml, create_memdb(), Yaml);
+test_basic_save_load! (mem_bincode, create_memdb(), Bincode);
+
+test_basic_save_load! (mmap_ron, create_mmapdb(), Ron);
+test_basic_save_load! (mmap_yaml, create_mmapdb(), Yaml);
+test_basic_save_load! (mmap_bincode, create_mmapdb(), Bincode);
+
+test_basic_save_load! (mmapsize_ron, create_mmapdb_with_size(10), Ron);
+test_basic_save_load! (mmapsize_yaml, create_mmapdb_with_size(10), Yaml);
+test_basic_save_load! (mmapsize_bincode, create_mmapdb_with_size(10), Bincode);
+
+test_basic_save_load! (path_ron, create_pathdb(), Ron);
+test_basic_save_load! (path_yaml, create_pathdb(), Yaml);
+test_basic_save_load! (path_bincode, create_pathdb(), Bincode);


### PR DESCRIPTION
Adds many unit tests (mainly to `lib.rs`) and some integration tests (`tests/integration_test.rs`).
Changes to the code:
- Fix the save order in `Database::put_data` with `save=true`. (During rebase I saw you fixed it independently in #78.) Also factors out the code shared between`Database::put_data` and `Database::save` (as was stated in a TODO comment) to a privat method `Database::save_data_locked`.
- Only read lock `Database.data` in functions which didn't require a write lock but did acquire one.
- Reduce potential for deadlocks as reported by TSAN (on the added tests), by never acquiring multiple locks at the same time. I don't think those deadlocks could actually be created through the API since all methods seem to always acquire the required lock on `Database.data` before the one on `Database.backend`, but I don't see any reason in the current implementation to not release the first lock before acquiring the second.
  Also the common code between `Database::load` and `Database::get_data` with `load=true` has been factored out (even further) into `Database::load_get_data_lock`, and `Database::inner_load` is commented out (no longer used).

There were quite some merge conflicts during rebase, so I hope I didn't break anything while fixing them. At least the whole test suite passes with ASAN, MSAN and TSAN.