### PR TITLE
Implement API from #67

### DIFF
--- a/examples/config.rs
+++ b/examples/config.rs
@@ -23,7 +23,7 @@ type DB = FileDatabase<Config, Ron>;
 
 lazy_static! {
     static ref CONFIG: DB = {
-        let db = FileDatabase::from_path("/tmp/config.ron", Config::default())
+        let db = FileDatabase::load_from_path_or_default("/tmp/config.ron")
             .expect("Create database from path");
         db.load().expect("Config to load");
         db

--- a/examples/full.rs
+++ b/examples/full.rs
@@ -20,7 +20,7 @@ struct Person {
 fn do_main() -> Result<(), failure::Error> {
     use std::collections::HashMap;
 
-    let db = FileDatabase::<HashMap<String, Person>, Ron>::from_path("test.ron", HashMap::new())?;
+    let db = FileDatabase::<HashMap<String, Person>, Ron>::load_from_path_or_default("test.ron")?;
 
     println!("Writing to Database");
     db.write(|db| {

--- a/examples/switching.rs
+++ b/examples/switching.rs
@@ -48,7 +48,7 @@ fn do_main() -> Result<(), failure::Error> {
 
     let db = db
         .with_deser(Yaml)
-        .with_backend(FileBackend::open("test.yml")?);
+        .with_backend(FileBackend::from_path_or_create("test.yml").map(|p| p.0)?);
     db.save()?;
 
     Ok(())

--- a/examples/switching.rs
+++ b/examples/switching.rs
@@ -20,7 +20,7 @@ struct Person {
 fn do_main() -> Result<(), failure::Error> {
     use std::collections::HashMap;
 
-    let db = FileDatabase::<HashMap<String, Person>, Ron>::from_path("test.ron", HashMap::new())?;
+    let db = FileDatabase::<HashMap<String, Person>, Ron>::load_from_path_or_default("test.ron")?;
 
     println!("Writing to Database");
     db.write(|db| {

--- a/src/deser.rs
+++ b/src/deser.rs
@@ -71,9 +71,9 @@ pub use self::bincode::Bincode;
 pub trait DeSerializer<T: Serialize + DeserializeOwned>:
     std::default::Default + Send + Sync + Clone
 {
-    /// Serializes a given value to a String
+    /// Serializes a given value to a [`String`].
     fn serialize(&self, val: &T) -> Result<Vec<u8>, failure::Error>;
-    /// Deserializes a String to a value
+    /// Deserializes a [`String`] to a value.
     fn deserialize<R: Read>(&self, s: R) -> Result<T, failure::Error>;
 }
 
@@ -81,7 +81,6 @@ pub trait DeSerializer<T: Serialize + DeserializeOwned>:
 mod ron {
     use std::io::Read;
 
-    use failure::ResultExt;
     use serde::de::DeserializeOwned;
     use serde::Serialize;
 
@@ -90,20 +89,17 @@ mod ron {
     use ron::ser::PrettyConfig;
 
     use crate::deser::DeSerializer;
-    use crate::error;
 
-    /// The Struct that allows you to use `ron` the Rusty Object Notation
+    /// The Struct that allows you to use `ron` the Rusty Object Notation.
     #[derive(Debug, Default, Clone)]
     pub struct Ron;
 
     impl<T: Serialize + DeserializeOwned> DeSerializer<T> for Ron {
         fn serialize(&self, val: &T) -> Result<Vec<u8>, failure::Error> {
-            Ok(to_ron_string(val, PrettyConfig::default())
-                .map(String::into_bytes)
-                .context(error::RustbreakErrorKind::Serialization)?)
+            Ok(to_ron_string(val, PrettyConfig::default()).map(String::into_bytes)?)
         }
         fn deserialize<R: Read>(&self, s: R) -> Result<T, failure::Error> {
-            Ok(from_ron_string(s).context(error::RustbreakErrorKind::Deserialization)?)
+            Ok(from_ron_string(s)?)
         }
     }
 }
@@ -112,26 +108,22 @@ mod ron {
 mod yaml {
     use std::io::Read;
 
-    use failure::ResultExt;
     use serde::de::DeserializeOwned;
     use serde::Serialize;
     use serde_yaml::{from_reader as from_yaml_string, to_string as to_yaml_string};
 
     use crate::deser::DeSerializer;
-    use crate::error;
 
-    /// The struct that allows you to use yaml
+    /// The struct that allows you to use yaml.
     #[derive(Debug, Default, Clone)]
     pub struct Yaml;
 
     impl<T: Serialize + DeserializeOwned> DeSerializer<T> for Yaml {
         fn serialize(&self, val: &T) -> Result<Vec<u8>, failure::Error> {
-            Ok(to_yaml_string(val)
-                .map(String::into_bytes)
-                .context(error::RustbreakErrorKind::Serialization)?)
+            Ok(to_yaml_string(val).map(String::into_bytes)?)
         }
         fn deserialize<R: Read>(&self, s: R) -> Result<T, failure::Error> {
-            Ok(from_yaml_string(s).context(error::RustbreakErrorKind::Deserialization)?)
+            Ok(from_yaml_string(s)?)
         }
     }
 }
@@ -141,12 +133,10 @@ mod bincode {
     use std::io::Read;
 
     use bincode::{deserialize_from, serialize};
-    use failure::ResultExt;
     use serde::de::DeserializeOwned;
     use serde::Serialize;
 
     use crate::deser::DeSerializer;
-    use crate::error;
 
     /// The struct that allows you to use bincode
     #[derive(Debug, Default, Clone)]
@@ -154,10 +144,10 @@ mod bincode {
 
     impl<T: Serialize + DeserializeOwned> DeSerializer<T> for Bincode {
         fn serialize(&self, val: &T) -> Result<Vec<u8>, failure::Error> {
-            Ok(serialize(val).context(error::RustbreakErrorKind::Serialization)?)
+            Ok(serialize(val)?)
         }
         fn deserialize<R: Read>(&self, s: R) -> Result<T, failure::Error> {
-            Ok(deserialize_from(s).context(error::RustbreakErrorKind::Deserialization)?)
+            Ok(deserialize_from(s)?)
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,3 +74,25 @@ impl From<Context<RustbreakErrorKind>> for RustbreakError {
 
 /// A simple type alias for errors
 pub type Result<T> = std::result::Result<T, RustbreakError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{RustbreakError, RustbreakErrorKind};
+    use failure::Context;
+    use std::any::Any;
+
+    #[test]
+    fn static_errorkind_impl_any() {
+        let err = RustbreakErrorKind::Backend;
+        let boxed: Box<dyn Any> = Box::new(err);
+        assert!(boxed.is::<RustbreakErrorKind>());
+    }
+
+    #[test]
+    fn static_error_impl_any() {
+        let context = RustbreakErrorKind::Serialization;
+        let err: RustbreakError = Context::new(context).into();
+        let boxed: Box<dyn Any> = Box::new(err);
+        assert!(boxed.is::<RustbreakError>());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,7 +520,7 @@ where
     /// Load data from backend and return this data.
     fn load_from_backend(backend: &mut Back, deser: &DeSer) -> error::Result<Data> {
         let new_data = deser
-            .deserialize(&backend.get_data().context(ErrorKind::Backend)?[..])
+            .deserialize(&backend.get_data()?[..])
             .context(ErrorKind::Deserialization)?;
 
         Ok(new_data)
@@ -552,7 +552,7 @@ where
         drop(lock);
 
         let mut backend = self.backend.lock().map_err(|_| ErrorKind::Poison)?;
-        backend.put_data(&ser).context(ErrorKind::Backend)?;
+        backend.put_data(&ser)?;
         Ok(())
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -108,7 +108,7 @@ fn create_filedb<S: DeSerializer<Data> + Debug>() -> FileDatabase<Data, S> {
 
 fn create_filedb_from_path<S: DeSerializer<Data> + Debug>() -> FileDatabase<Data, S> {
     let file = tempfile::NamedTempFile::new().expect("could not create temporary file");
-    FileDatabase::from_path(file.path(), Data::default()).expect("could not create database")
+    FileDatabase::create_at_path(file.path(), Data::default()).expect("could not create database")
 }
 
 fn create_memdb<S: DeSerializer<Data> + Debug>() -> MemoryDatabase<Data, S> {
@@ -125,7 +125,7 @@ fn create_mmapdb_with_size<S: DeSerializer<Data> + Debug>(size: usize) -> MmapDa
 
 fn create_pathdb<S: DeSerializer<Data> + Debug>() -> PathDatabase<Data, S> {
     let file = tempfile::NamedTempFile::new().expect("could not create temporary file");
-    PathDatabase::from_path(file.path().to_owned(), Data::default())
+    PathDatabase::create_at_path(file.path().to_owned(), Data::default())
         .expect("could not create database")
 }
 


### PR DESCRIPTION
Implements the API as discussed in #67 to allow creating and directly loading files, and initialise files with data (only on creation).
It could use some additional tests though.