### PR TITLE
Test on all operating systems and make Miri run on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,10 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Get latest toolchain version with miri
-        run: echo "::set-env name=TOOLCHAIN::$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)"
+        run: echo "TOOLCHAIN=$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> $GITHUB_ENV
 
       - name: Install latest nightly toolchain with miri
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
It might be a good idea to test on all operating systems, since they have differences in memory management and file operations which might cause bugs. It should run the tests in parallel, so there shouldn't be any significant overhead for this change.

This also fixes the set_env command to make Miri actually run (though I haven't fixed any bugs, so it still fails, but now it does so because it actually runs).