### PR TITLE
Fix tests on windows and add UB warning for YAML DeSer

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ features = ["yaml_enc"]
 
 You can now use `rustbreak::deser::Yaml` as deserialization struct.
 
+🔥🔥
+__Warning__: Using this deserializer can trigger *Undefined Behaviour (UB)*. It
+is *strongly* recommended to *not* use this deserializer until these issues are
+fixed. See [tracking issue #87] for more details.
+🔥🔥
+
 ### Ron
 
 If you would like to use [`ron`](https://github.com/ron-rs/ron) you need to
@@ -143,3 +149,4 @@ You can now use `rustbreak::deser::Bincode` as deserialization struct.
 
 [doc]:http://neikos.me/rustbreak/rustbreak/index.html
 [Daybreak]:https://propublica.github.io/daybreak/
+[tracking issue #87]: https://github.com/TheNeikos/rustbreak/issues/87

--- a/src/deser.rs
+++ b/src/deser.rs
@@ -30,7 +30,6 @@ pub use self::bincode::Bincode;
 /// extern crate thiserror;
 /// extern crate serde;
 /// #[macro_use]
-///
 /// use serde::de::Deserialize;
 /// use serde::Serialize;
 /// use std::io::Read;
@@ -69,7 +68,8 @@ pub use self::bincode::Bincode;
 /// fn main() {}
 /// ```
 ///
-/// **Important**: You can only return custom errors if the `other_errors` feature is enabled
+/// **Important**: You can only return custom errors if the `other_errors`
+/// feature is enabled
 pub trait DeSerializer<T: Serialize + DeserializeOwned>:
     std::default::Default + Send + Sync + Clone
 {
@@ -93,7 +93,7 @@ mod ron {
     use crate::deser::DeSerializer;
     use crate::error;
 
-    /// The Struct that allows you to use `ron` the Rusty Object Notation.
+    /// The Struct that allows you to use `ron`, the Rusty Object Notation.
     #[derive(Debug, Default, Clone)]
     pub struct Ron;
 
@@ -118,7 +118,19 @@ mod yaml {
     use crate::deser::DeSerializer;
     use crate::error;
 
-    /// The struct that allows you to use yaml.
+    /// The struct that allows you to use yaml. 🔥 *do not use* 🔥
+    ///
+    /// 🔥🔥 __Warning__: Using this [`DeSerializer`] can trigger *Undefined
+    /// Behaviour (UB)*. 🔥🔥 It is *strongly* recommended to *not* use this
+    /// [`DeSerializer`] until these issues are fixed. The UB is triggered
+    /// in a transitive dependency (namely [`linked_hash_map`]) of Rustbreak.
+    /// There is nothing the Rustbreak devs can do about this.
+    /// The UB is real and reachable. It triggered by the Rustbreak test suite,
+    /// and detected by `miri`. See the [tracking issue #87] for more details.
+    /// 🔥🔥 __DO NOT USE__ 🔥🔥
+    ///
+    /// [`linked_hash_map`]: https://github.com/contain-rs/linked-hash-map
+    /// [tracking issue #87]: https://github.com/TheNeikos/rustbreak/issues/87
     #[derive(Debug, Default, Clone)]
     pub struct Yaml;
 


### PR DESCRIPTION
Fix tempfile leak in integration test, fix tests failing on windows due to open tempfile handles locking those files and document the YAML DeSer UB in the README and the API documentation.